### PR TITLE
Custom headers

### DIFF
--- a/config/application.config.inc.php.example
+++ b/config/application.config.inc.php.example
@@ -18,7 +18,10 @@
 	define("SMTP_AUTHENTICATION_USERNAME", "");
 	define("SMTP_AUTHENTICATION_PASSWORD", "");
 	
-	define("PHPMAILER_LANGUAGE", "en");
+        define("CHARSET", "utf-8"); //Used in Content-Type Email Header
+        define("CONTENT_TRANSFER_ENCODING", "8bit"); //Content-Transfer-Encoding Email Header. May be 7bit, 8bit, quoted-printable or base64
+
+        define("PHPMAILER_LANGUAGE", "en");
 	
 	define("DEFAULT_TIMEZONE", "UTC");
 

--- a/docs/emailqueue.sql
+++ b/docs/emailqueue.sql
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS `emails` (
   `content_nonhtml` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci COMMENT 'Optional. A plain-text version of the email for old clients.',
   `list_unsubscribe_url` varchar(255) DEFAULT NULL COMMENT 'Optional. The URL where users can unsubscribe from the newsletter. Highly recommended.',
   `attachments` text CHARACTER SET utf8 COLLATE utf8_unicode_ci COMMENT 'A serialized array of hash arrays specifying the files to be attached to this email. See example.php on how to build this array.',
-  `is_embed_images` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Whether to automatically convert <IMG ... /> tags found on the email content to embedded images that are transferred along with the email itself instead of being referenced to external URLs. Can bring you some interesting benefits, but also hugely increases the data transfer.'
+  `is_embed_images` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Whether to automatically convert <IMG ... /> tags found on the email content to embedded images that are transferred along with the email itself instead of being referenced to external URLs. Can bring you some interesting benefits, but also hugely increases the data transfer.',
+  `custom_headers` text CHARACTER SET utf8 COLLATE utf8_unicode_ci COMMENT 'A serialized array with custom headers to be added when sending with PHPMailer.  NB! The value should not be an empty string, in spite of the fact that PHPMailer::addCustomHeader() allows it.'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `incidences` (

--- a/scripts/emailqueue_inject.class.php
+++ b/scripts/emailqueue_inject.class.php
@@ -51,7 +51,8 @@
             $content_nonhtml = "",
             $list_unsubscribe_url = "",
             $attachments = false,
-            $is_embed_images = false
+            $is_embed_images = false,
+            $custom_headers = array()
         ) {
             $this->db_connect();
         
@@ -85,6 +86,13 @@
                     }
                 }
             }
+
+            if ($custom_headers) {
+                if (!is_array($custom_headers)) {
+                    echo "Emailqueue inject error: custom headers parameter must be an array.";
+                    return false;
+                }
+            }
             
             $result = mysqli_query
             (
@@ -116,7 +124,8 @@
 						content_nonhtml,
 						list_unsubscribe_url,
                         attachments,
-                        is_embed_images
+                        is_embed_images,
+                        custom_headers
 					)
 					values
 					(
@@ -144,7 +153,8 @@
 						'".$content_nonhtml."',
 						'".$list_unsubscribe_url."',
                         ".($attachments ? "'".serialize($attachments)."'" : "null").",
-                        ".($is_embed_images ? "1" : "0")."
+                        ".($is_embed_images ? "1" : "0").",
+                        ".($custom_headers ? "'".serialize($custom_headers)."'" : "null")."
 					)
 				"
 			);


### PR DESCRIPTION
The main change I've made within is the support for custom email headers.

There are several changes made:
1. I've added custom_headers column in the database and an option to inject custom headers, when envoking the inject function. By delivery the custom headers are added through the PHPMailer::addCustomHeader() function.
2. The email encoding is now configurable. It is still utf-8 by default, but if someone needs something different, he/she can change it in the application config.
3. There is an option in the application config for changing the content-transfer-encoding header. It is by default 8bit, as this is the default of PHPMailer. You can change it through a custom header too. The custom header would take precedence. The idea behind this is, that in the most cases you always send your emails with the same encoding. But if you need to send 90% for the emails as qouted-printable and only several messages as base64, you are able to do it through the custom header only for the several base64 messages.
4. There were two bugs with the Body/AltBody. First, the AltBody text „Please use an HTML compatible email viewer!“ was added always, not only by html messages. Second, regardless of the type of the message, the body was composed through the PHPMailer::msgHTML() function, which always creates AltBody (when not supplied, it strips the html tags from the body and adds it as AltBody). And after that PHPMailer assumes you have a html message, because you have AltBody and sends the message as multipart/alternative, which is not what you want. When the messages isn't marked as HTML now, the body is assigned directly to the PHPMailer::Body attribute, which is the right way to do it.