### PR TITLE
	base64 encode/decode of attachements 

### DIFF
--- a/classes/manager.class.php
+++ b/classes/manager.class.php
@@ -54,7 +54,7 @@
             else {
                 $attachments = unserialize($message["attachments"]);
                 foreach ($attachments as $attachment)
-                    $attachmentsInfo .= $attachment["path"]."<br>";
+                    $attachments = unserialize(base64_decode($message["attachments"]));
             }
             
             $retr .=

--- a/scripts/delivery.php
+++ b/scripts/delivery.php
@@ -229,7 +229,7 @@
 
 	                // Add attachments
 	                if($email["attachments"]) {
-	                	$attachments = unserialize($email["attachments"]);
+	                	$attachments = unserialize(base64_decode($email["attachments"]));
 	                	if (is_array($attachments)) {
 	                    	foreach ($attachments as $attachment) {
 

--- a/scripts/emailqueue_inject.class.php
+++ b/scripts/emailqueue_inject.class.php
@@ -154,7 +154,7 @@
 						'".$list_unsubscribe_url."',
                         ".($attachments ? "'".serialize($attachments)."'" : "null").",
                         ".($is_embed_images ? "1" : "0").",
-                        ".($custom_headers ? "'".serialize($custom_headers)."'" : "null")."
+                        ".($custom_headers ? "'".base64_encode(serialize($attachments))."'" : "null")."
 					)
 				"
 			);


### PR DESCRIPTION
Non encoded, attachements content can break the insert sql (an alternative would be to "escape" the attachement content)