### PR TITLE
Changing to use <?php and general formatting cleanup

### DIFF
--- a/classes/home.class.php
+++ b/classes/home.class.php
@@ -1,131 +1,129 @@
-<?
+<?php
 
-	class home {
-		function getinfo() {
-		  	global $db;
-			global $messages;
-			
-			// Get statistical data
-			// Get total number of sent messages
-			$db->query("select count(*) as numberof from emails where is_sent = 1");
-			$row = $db->fetchrow();
-			$messages_sent = $row["numberof"];
-			
-			// Get total number of cancelled messages
-			$db->query("select count(*) as numberof from emails where is_cancelled = 1");
-			$row = $db->fetchrow();
-			$messages_cancelled = $row["numberof"];
-			
-			// Get total number of messages injected today
-			$db->query("select count(*) as numberof from emails where YEAR(date_injected) = ".date("Y")." and MONTH(date_injected) = ".date("n")." and DAYOFMONTH(date_injected) = ".date("j")."");
-			$row = $db->fetchrow();
-			$messages_injected_today = $row["numberof"];
-			
-			// Get total number of messages injected last hour
-			$db->query("select count(*) as numberof from emails where date_injected >= '".date("Y-n-j H:i:s", mktime()-(60*60))."'");
-			$row = $db->fetchrow();
-			$messages_injected_lasthour = $row["numberof"];
-			
-			// Get total number of messages in queue
-			$db->query("select count(*) as numberof from emails where is_sent = 0 and is_cancelled = 0 and is_blocked = 0");
-			$row = $db->fetchrow();
-			$messages_in_queue = $row["numberof"];
+class home {
+	function getinfo() {
+	  	global $db;
+		global $messages;
+		
+		// Get statistical data
+		// Get total number of sent messages
+		$db->query("select count(*) as numberof from emails where is_sent = 1");
+		$row = $db->fetchrow();
+		$messages_sent = $row["numberof"];
+		
+		// Get total number of cancelled messages
+		$db->query("select count(*) as numberof from emails where is_cancelled = 1");
+		$row = $db->fetchrow();
+		$messages_cancelled = $row["numberof"];
+		
+		// Get total number of messages injected today
+		$db->query("select count(*) as numberof from emails where YEAR(date_injected) = ".date("Y")." and MONTH(date_injected) = ".date("n")." and DAYOFMONTH(date_injected) = ".date("j")."");
+		$row = $db->fetchrow();
+		$messages_injected_today = $row["numberof"];
+		
+		// Get total number of messages injected last hour
+		$db->query("select count(*) as numberof from emails where date_injected >= '".date("Y-n-j H:i:s", mktime()-(60*60))."'");
+		$row = $db->fetchrow();
+		$messages_injected_lasthour = $row["numberof"];
+		
+		// Get total number of messages in queue
+		$db->query("select count(*) as numberof from emails where is_sent = 0 and is_cancelled = 0 and is_blocked = 0");
+		$row = $db->fetchrow();
+		$messages_in_queue = $row["numberof"];
 
-            global $devel_emails;
-			
-			$retr .= "
-                <div class=block>
-                    <div class=block_title>Status</div>
-		  			<div class=pairs>
-                        <div class=pair><div class=key>Environment</div><div class=value>".(IS_DEVEL_ENVIRONMENT ? "Development" : "Production")."</div></div>
-                        ".(IS_DEVEL_ENVIRONMENT ? "<div class=pair><div class=key>Deliver only to</div><div class=value>".implode(", ", $devel_emails)."</div></div>" : "")."
-                        <div class=pair><div class=key>Maximum delivery timeout</div><div class=value>".number_format(MAXIMUM_DELIVERY_TIMEOUT, 0, ".", ",")." seconds</div></div>
-                        <div class=pair><div class=key>Delivery interval</div><div class=value>".number_format(DELIVERY_INTERVAL*10, 0, ".", ",")." ms.</div></div>
-                        <div class=pair><div class=key>Maximum retry attempts</div><div class=value>".SENDING_RETRY_MAX_ATTEMPTS."</div></div>
-                        <div class=pair><div class=key>Maximum delivers per call</div><div class=value>".number_format(MAX_DELIVERS_A_TIME, 0, ".", ",")."</div></div>
-                        <div class=pair><div class=key>SMTP server</div><div class=value>".(SMTP_SERVER == "127.0.0.1" || SMTP_SERVER == "localhost" ? "Same server" : SMTP_SERVER)."</div></div>
-                        <div class=pair><div class=key>Purge messages older than</div><div class=value>".PURGE_OLDER_THAN_DAYS." days</div></div>
-                    </div>
-                    <div class=pairs>
-                        <div class=pair><div class=key>Messages sent</div><div class=value>".number_format($messages_sent, 0, ".", ",")."</div></div>
-                        <div class=pair><div class=key>Messages cancelled</div><div class=value>".number_format($messages_cancelled, 0, ".", ",")."</div></div>
-                        <div class=pair><div class=key>Messages injected today</div><div class=value>".number_format($messages_injected_today, 0, ".", ",")."</div></div>
-                        <div class=pair><div class=key>Messages injected last hour</div><div class=value>".number_format($messages_injected_lasthour, 0, ".", ",")."</div></div>
-                        <div class=pair><div class=key>Messages in queue</div><div class=value>".number_format($messages_in_queue, 0, ".", ",")."</div></div>
-		  			</div>
+        global $devel_emails;
+		
+		$retr .= "
+            <div class=block>
+                <div class=block_title>Status</div>
+	  			<div class=pairs>
+                    <div class=pair><div class=key>Environment</div><div class=value>".(IS_DEVEL_ENVIRONMENT ? "Development" : "Production")."</div></div>
+                    ".(IS_DEVEL_ENVIRONMENT ? "<div class=pair><div class=key>Deliver only to</div><div class=value>".implode(", ", $devel_emails)."</div></div>" : "")."
+                    <div class=pair><div class=key>Maximum delivery timeout</div><div class=value>".number_format(MAXIMUM_DELIVERY_TIMEOUT, 0, ".", ",")." seconds</div></div>
+                    <div class=pair><div class=key>Delivery interval</div><div class=value>".number_format(DELIVERY_INTERVAL*10, 0, ".", ",")." ms.</div></div>
+                    <div class=pair><div class=key>Maximum retry attempts</div><div class=value>".SENDING_RETRY_MAX_ATTEMPTS."</div></div>
+                    <div class=pair><div class=key>Maximum delivers per call</div><div class=value>".number_format(MAX_DELIVERS_A_TIME, 0, ".", ",")."</div></div>
+                    <div class=pair><div class=key>SMTP server</div><div class=value>".(SMTP_SERVER == "127.0.0.1" || SMTP_SERVER == "localhost" ? "Same server" : SMTP_SERVER)."</div></div>
+                    <div class=pair><div class=key>Purge messages older than</div><div class=value>".PURGE_OLDER_THAN_DAYS." days</div></div>
                 </div>
-			";
-		  
-		  	// Waiting messages list
-		  	$retr .= "
-				<div class=block>
-		  			<div class=block_title>First ".QUEUED_MESSAGES." messages waiting to be delivered</div>
-		  	";
-		  	
-		  	$db->query("
-		  		select			*
-		  		from			emails
-		  		where			is_sent = 0
-		  		and				is_cancelled = 0
-		  		order by		is_inmediate desc, priority asc, (date_queued is null) asc, date_injected desc
-		  		limit           0, ".QUEUED_MESSAGES."
-		  	");
-		  	$list = $messages->get_list();
-		  	if(!$list)
-		  		$list = "No messages waiting";
-		  	
-		  	$retr .= "
-		  			".$list."
-		  		</div>
-		  	";
-		  	
-		  	// Latest delivered messages
-		  	$retr .= "
-				<div class=block>
-		  			<div class=block_title>Last ".LATEST_DELIVERED_MESSAGES." delivered messages</div>
-		  	";
-		  	
-		  	$db->query("
-		  		select			*
-		  		from			emails
-		  		where			is_sent
-		  		order by		date_sent desc
-		  		limit			0, ".LATEST_DELIVERED_MESSAGES."
-		  	");
-		  	$list = $messages->get_list();
-		  	if(!$list)
-		  		$list = "No delivered messages";
-		  	
-		  	$retr .=
-		  	"
-		  			".$list."
-		  		</div>
-		  	";
-		  	
-		  	// Cancelled
-		  	$retr .= "
-				<div class=block>
-		  			<div class=block_title>Last ".LATEST_CANCELLED_MESSAGES." cancelled messages</div>
-		  	";
-		  	
-		  	$db->query("
-		  		select			*
-		  		from			emails
-		  		where			is_cancelled = 1
-		  		order by		date_sent desc
-		  		limit           0, ".LATEST_CANCELLED_MESSAGES."
-		  	");
-		  	$list = $messages->get_list();
-		  	if(!$list)
-		  		$list = "None";
-		  	
-		  	$retr .="
-		  			".$list."
-		  		</div>
-		  	";
-		  	
-			return $retr;
-		}
+                <div class=pairs>
+                    <div class=pair><div class=key>Messages sent</div><div class=value>".number_format($messages_sent, 0, ".", ",")."</div></div>
+                    <div class=pair><div class=key>Messages cancelled</div><div class=value>".number_format($messages_cancelled, 0, ".", ",")."</div></div>
+                    <div class=pair><div class=key>Messages injected today</div><div class=value>".number_format($messages_injected_today, 0, ".", ",")."</div></div>
+                    <div class=pair><div class=key>Messages injected last hour</div><div class=value>".number_format($messages_injected_lasthour, 0, ".", ",")."</div></div>
+                    <div class=pair><div class=key>Messages in queue</div><div class=value>".number_format($messages_in_queue, 0, ".", ",")."</div></div>
+	  			</div>
+            </div>
+		";
+	  
+	  	// Waiting messages list
+	  	$retr .= "
+			<div class=block>
+	  			<div class=block_title>First ".QUEUED_MESSAGES." messages waiting to be delivered</div>
+	  	";
+	  	
+	  	$db->query("
+	  		select			*
+	  		from			emails
+	  		where			is_sent = 0
+	  		and				is_cancelled = 0
+	  		order by		is_inmediate desc, priority asc, (date_queued is null) asc, date_injected desc
+	  		limit           0, ".QUEUED_MESSAGES."
+	  	");
+	  	$list = $messages->get_list();
+	  	if(!$list)
+	  		$list = "No messages waiting";
+	  	
+	  	$retr .= "
+	  			".$list."
+	  		</div>
+	  	";
+	  	
+	  	// Latest delivered messages
+	  	$retr .= "
+			<div class=block>
+	  			<div class=block_title>Last ".LATEST_DELIVERED_MESSAGES." delivered messages</div>
+	  	";
+	  	
+	  	$db->query("
+	  		select			*
+	  		from			emails
+	  		where			is_sent
+	  		order by		date_sent desc
+	  		limit			0, ".LATEST_DELIVERED_MESSAGES."
+	  	");
+	  	$list = $messages->get_list();
+	  	if(!$list)
+	  		$list = "No delivered messages";
+	  	
+	  	$retr .=
+	  	"
+	  			".$list."
+	  		</div>
+	  	";
+	  	
+	  	// Cancelled
+	  	$retr .= "
+			<div class=block>
+	  			<div class=block_title>Last ".LATEST_CANCELLED_MESSAGES." cancelled messages</div>
+	  	";
+	  	
+	  	$db->query("
+	  		select			*
+	  		from			emails
+	  		where			is_cancelled = 1
+	  		order by		date_sent desc
+	  		limit           0, ".LATEST_CANCELLED_MESSAGES."
+	  	");
+	  	$list = $messages->get_list();
+	  	if(!$list)
+	  		$list = "None";
+	  	
+	  	$retr .="
+	  			".$list."
+	  		</div>
+	  	";
+	  	
+		return $retr;
 	}
-
-?>
+}

--- a/classes/html.class.php
+++ b/classes/html.class.php
@@ -1,56 +1,54 @@
-<?
+<?php
 
-	class html {
+class html {
 
-		var $title;
-		var $menu_options;
+	var $title;
+	var $menu_options;
 
-		function head_simple() {
-			return
-				"
-					<html>
-					<header>
-						<title>EMailqueue</title>
-						<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">
-						<link rel=\"stylesheet\" type=\"text/css\" href=\"gfx/css/main.css\">
-						<link rel=\"shortcut icon\" href=\"favicon.ico\" type=\"image/x-icon\">
-						<link rel=\"icon\" href=\"favicon.ico\" type=\"image/x-icon\">
-						<script>
-							function confirmation(message, urlifok) {
-								var result=confirm(message);
-								if(result)
-									document.location = urlifok;
-							}
-						</script>
-					</header>
-					<body>
-				";
-		}
-
-		function head() {
-			global $now;
-
-			return
-				$this->head_simple().
-				"
-					<div id=\"head\">
-					<img src=\"gfx/img/logo_small.png\" class=\"logo\" title=\"Emailqueue\" />
-					<div class=\"title\">Emailqueue v".VERSION."<br>".date("d.m.Y H'i\"s e", $now)."<br><a href=\"".OFFICIAL_PAGE_URL."\" target=\"_newwindow\">official page</a></div>
-					</div>
-				";
-		}
-
-		function foot_simple() {
-			return
+	function head_simple() {
+		return
 			"
-				</body>
-				</html>
+				<html>
+				<header>
+					<title>EMailqueue</title>
+					<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">
+					<link rel=\"stylesheet\" type=\"text/css\" href=\"gfx/css/main.css\">
+					<link rel=\"shortcut icon\" href=\"favicon.ico\" type=\"image/x-icon\">
+					<link rel=\"icon\" href=\"favicon.ico\" type=\"image/x-icon\">
+					<script>
+						function confirmation(message, urlifok) {
+							var result=confirm(message);
+							if(result)
+								document.location = urlifok;
+						}
+					</script>
+				</header>
+				<body>
 			";
-		}
-
-		function foot() {
-			return $this->foot_simple();
-		}
 	}
 
-?>
+	function head() {
+		global $now;
+
+		return
+			$this->head_simple().
+			"
+				<div id=\"head\">
+				<img src=\"gfx/img/logo_small.png\" class=\"logo\" title=\"Emailqueue\" />
+				<div class=\"title\">Emailqueue v".VERSION."<br>".date("d.m.Y H'i\"s e", $now)."<br><a href=\"".OFFICIAL_PAGE_URL."\" target=\"_newwindow\">official page</a></div>
+				</div>
+			";
+	}
+
+	function foot_simple() {
+		return
+		"
+			</body>
+			</html>
+		";
+	}
+
+	function foot() {
+		return $this->foot_simple();
+	}
+}

--- a/classes/logger.class.php
+++ b/classes/logger.class.php
@@ -1,91 +1,89 @@
-<?
+<?php
 
-	class logger {
-		var $filename_delivery;
-		var $filename_incidences;
+class logger {
+	var $filename_delivery;
+	var $filename_incidences;
+	
+	function logger() {
+		$this->filename_delivery = APP_DIR.LOGS_DIR."/".$this->get_log_filename("delivery");
+		$this->filename_incidences = APP_DIR.LOGS_DIR."/".$this->get_log_filename("incidences");
 		
-		function logger() {
-			$this->filename_delivery = APP_DIR.LOGS_DIR."/".$this->get_log_filename("delivery");
-			$this->filename_incidences = APP_DIR.LOGS_DIR."/".$this->get_log_filename("incidences");
-			
-			/*
-			// Check for writable files if they already exists
-			if(file_exists($this->filename_delivery) && !is_writable($this->filename_delivery))
-			{
-				echo "Error: ".$this->filename_delivery." is not writable.";
-				die;
-			}
-			
-			if(file_exists($this->filename_incidences) && !is_writable($this->filename_incidences))
-			{
-				echo "Error: ".$this->filename_incidences." is not writable.";
-				die;
-			}
-			*/
-			
-			/*
-			// Try to open log files for writing just to check (also creates them with 0 filesize if don't exist)
-			if(!$handle = fopen($this->filename_delivery, "a"))
-			{
-			  	echo "Error: ".$this->filename_delivery." can't be opened for writing.";
-			  	die;
-			}
-			else
-			{
-				fclose($handle);
-			}
-			
-			if(!$handle = fopen($this->filename_incidences, "a"))
-			{
-			  	echo "Error: ".$this->filename_incidences." can't be opened for writing.";
-			  	die;
-			}
-			else
-			{
-				fclose($handle);
-			}
-			*/
+		/*
+		// Check for writable files if they already exists
+		if(file_exists($this->filename_delivery) && !is_writable($this->filename_delivery))
+		{
+			echo "Error: ".$this->filename_delivery." is not writable.";
+			die;
 		}
-	  
-		function add_log_delivery($data) {
-			/*
-			$content = $this->get_logline($data);
-			$handle = fopen($this->filename_delivery, "a");
-			if(fwrite($handle, $content) === FALSE)
-			{
-			  	echo "Error: can't write to ".$this->filename_delivery;
-			  	die;
-			}
+		
+		if(file_exists($this->filename_incidences) && !is_writable($this->filename_incidences))
+		{
+			echo "Error: ".$this->filename_incidences." is not writable.";
+			die;
+		}
+		*/
+		
+		/*
+		// Try to open log files for writing just to check (also creates them with 0 filesize if don't exist)
+		if(!$handle = fopen($this->filename_delivery, "a"))
+		{
+		  	echo "Error: ".$this->filename_delivery." can't be opened for writing.";
+		  	die;
+		}
+		else
+		{
 			fclose($handle);
-			*/
 		}
-	
-		function add_log_incidence($data) {
-			/*
-			$content = $this->get_logline($data);
-			$handle = fopen($this->filename_incidences, "a");
-			if(fwrite($handle, $content) === FALSE)
-			{
-			  	echo "Error: can't write to ".$this->filename_incidences;
-			  	die;
-			}
+		
+		if(!$handle = fopen($this->filename_incidences, "a"))
+		{
+		  	echo "Error: ".$this->filename_incidences." can't be opened for writing.";
+		  	die;
+		}
+		else
+		{
 			fclose($handle);
-			*/
 		}
-	
-		function get_logline($data) {
-		  	$retr .= date(LOGS_DATA_DATEFORMAT)."|";
-		  	for($i=0; $i<sizeof($data); $i++)
-		  		$data[$i] = str_replace("|", " ", $data[$i]);
-			$retr .= implode("|", $data);
-			$retr .= "\r\n";
-			return $retr;
+		*/
+	}
+  
+	function add_log_delivery($data) {
+		/*
+		$content = $this->get_logline($data);
+		$handle = fopen($this->filename_delivery, "a");
+		if(fwrite($handle, $content) === FALSE)
+		{
+		  	echo "Error: can't write to ".$this->filename_delivery;
+		  	die;
 		}
-	
-		function get_log_filename($preffix) {
-			global $now;
-			return $preffix."_".date(LOGS_FILENAME_DATEFORMAT, $now).".log";
-		}
+		fclose($handle);
+		*/
 	}
 
-?>
+	function add_log_incidence($data) {
+		/*
+		$content = $this->get_logline($data);
+		$handle = fopen($this->filename_incidences, "a");
+		if(fwrite($handle, $content) === FALSE)
+		{
+		  	echo "Error: can't write to ".$this->filename_incidences;
+		  	die;
+		}
+		fclose($handle);
+		*/
+	}
+
+	function get_logline($data) {
+	  	$retr .= date(LOGS_DATA_DATEFORMAT)."|";
+	  	for($i=0; $i<sizeof($data); $i++)
+	  		$data[$i] = str_replace("|", " ", $data[$i]);
+		$retr .= implode("|", $data);
+		$retr .= "\r\n";
+		return $retr;
+	}
+
+	function get_log_filename($preffix) {
+		global $now;
+		return $preffix."_".date(LOGS_FILENAME_DATEFORMAT, $now).".log";
+	}
+}

--- a/classes/manager.class.php
+++ b/classes/manager.class.php
@@ -1,264 +1,262 @@
-<?
+<?php
 
-	class manager {
-		function run() {
-            global $utils;
-            
-            $aa = $utils->getglobal("aa");
-            
-            switch($aa) {
-                case "view":
-                    $retr .= $this->view();
-                    break;
-                
-                case "view_iframe_body":
-                    $retr .= $this->view_iframe_body();
-                    break;
-				
-				case "block":
-					$retr .= $this->block();
-					break;
-				
-				case "unblock":
-					$retr .= $this->unblock();
-					break;
-				
-				case "cancel":
-					$retr .= $this->cancel();
-					break;
-				
-				case "requeue":
-					$retr .= $this->requeue();
-					break;
-            }
-            
-            return $retr;
-		}
+class manager {
+	function run() {
+        global $utils;
         
-        function view() {
-            global $db;
-            global $utils;
+        $aa = $utils->getglobal("aa");
+        
+        switch($aa) {
+            case "view":
+                $retr .= $this->view();
+                break;
             
-            $email_id = $utils->getglobal("email_id");
-            
-            $result = $db->query("select * from emails where id = ".$email_id);
+            case "view_iframe_body":
+                $retr .= $this->view_iframe_body();
+                break;
 			
-			if (!$result || !$db->isanyresult())
-				return "Error: Message ".$email_id." does not exists.";
+			case "block":
+				$retr .= $this->block();
+				break;
 			
-            $message = $db->fetchrow();
-
-            // Build attachments info
-            if (!$message["attachments"])
-                $attachmentsInfo = "No attachments";
-            else {
-                $attachments = unserialize($message["attachments"]);
-                foreach ($attachments as $attachment)
-                    $attachmentsInfo .= $attachment["path"]."<br>";
-            }
-            
-            $retr .=
-            "
-				<div class=block><a href=\"javascript:history.go(-1);\" class=button>&laquo; back</a></div>
-				<div class=block>
-					<div class=block_title>Message #".$email_id."</div>					
-		  			
-                        <div class=pairs>
-                            <div class=pair>
-                                <div class=key>Foreign id A</div>
-                                <div class=value>".(!$message["foreign_id_a"] ? "none" : $message["foreign_id_a"])."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Foreign id B</div>
-                                <div class=value>".(!$message["foreign_id_b"] ? "none" : $message["foreign_id_b"])."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Priority</div>
-                                <div class=value>".$message["priority"]."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Queued for inmediate sending</div>
-                                <div class=value>".($message["is_inmediate"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Sent</div>
-                                <div class=value>".($message["is_sent"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Cancelled</div>
-                                <div class=value>".($message["is_cancelled"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Blocked</div>
-                                <div class=value>".($message["is_blocked"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Being sent now</div>
-                                <div class=value>".($message["is_sendingnow"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>No. of times sent</div>
-                                <div class=value>".($message["send_count"] ? $message["send_count"]." times" : "not sent")."</div>
-                            </div>
-                        </div>
-                        <div class=pairs>
-                            <div class=pair>
-                                <div class=key>Injected on</div>
-                                <div class=value>".$utils->date_specialformat(strtotime($message["date_injected"]))."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Queued for</div>
-                                <div class=value>".
-                                (
-                                    $message["date_queued"]
-                                    ?
-                                    $utils->date_specialformat(strtotime($message["date_queued"]))
-                                    :
-                                    "none".($message["is_inmediate"] ? ", queued for inmediate sending" : ", and not queued for inmediate sending")                                
-                                ).
-                                "</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Sent on</div>
-                                <div class=value>".
-                                (
-                                    $message["date_sent"]
-                                    ?
-                                    $utils->date_specialformat(strtotime($message["date_sent"]))
-                                    :
-                                    "not sent"                                
-                                ).
-                                "</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>HTML format</div>
-                                <div class=value>".($message["is_html"] ? "Yes" : "No")."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>From</div>
-                                <div class=value>".$message["from"].($message["from_name"] ? " [".$message["from_name"]."]" : "")."</div>
-                            </div>
-							<div class=pair>
-                                <div class=key>To</div>
-                                <div class=value>".$message["to"]."</div>
-                            </div>
-							<div class=pair>
-                                <div class=key>Reply to</div>
-                                <div class=value>".
-								(
-									$message["replyto"]
-									?
-									$message["replyto"].($message["replyto_name"] ? " [".$message["replyto_name"]."]" : "")
-									:
-									"none"
-								).
-								"</div>
-                            </div>
-							<div class=pair>
-                                <div class=key>Subject</div>
-                                <div class=value>".$message["subject"]."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Attachments</div>
-                                <div class=value>".$attachmentsInfo."</div>
-                            </div>
-                            <div class=pair>
-                                <div class=key>Embed images</div>
-                                <div class=value>".($message["is_embed_images"] ? "Yes" : "No")."</div>
-                            </div>
-
-                        </div>
-                </div>
-                <iframe class=\"message_preview\" src=\"?a=manager&aa=view_iframe_body&email_id=".$message["id"]."\"></iframe>
-            ";
-            
-            return $retr;
+			case "unblock":
+				$retr .= $this->unblock();
+				break;
+			
+			case "cancel":
+				$retr .= $this->cancel();
+				break;
+			
+			case "requeue":
+				$retr .= $this->requeue();
+				break;
         }
         
-        function view_iframe_body() {
-            global $db;
-            global $utils;
-            
-            $email_id = $utils->getglobal("email_id");
-            
-            $db->query("select * from emails where id = ".$email_id);
-            $message = $db->fetchrow();
-            
-            return $message["content"];	
-        }
+        return $retr;
+	}
+    
+    function view() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $result = $db->query("select * from emails where id = ".$email_id);
 		
-		function block() {
-            global $db;
-            global $utils;
-            
-            $email_id = $utils->getglobal("email_id");
-            
-            $result = $db->query("select * from emails where id = ".$email_id);
-			
-			if (!$result || !$db->isanyresult())
-				return "Error: Message ".$email_id." does not exists.";
-			
-            $message = $db->fetchrow();
-			
-			$db->query("update emails set is_blocked = 1 where id = ".$email_id); 
-			
-			$utils->redirect_javascript("?a=home");
-		}
+		if (!$result || !$db->isanyresult())
+			return "Error: Message ".$email_id." does not exists.";
 		
-		function unblock() {
-            global $db;
-            global $utils;
-            
-            $email_id = $utils->getglobal("email_id");
-            
-            $result = $db->query("select * from emails where id = ".$email_id);
-			
-			if (!$result || !$db->isanyresult())
-				return "Error: Message ".$email_id." does not exists.";
-			
-            $message = $db->fetchrow();
-			
-			$db->query("update emails set is_blocked = 0 where id = ".$email_id); 
-			
-			$utils->redirect_javascript("?a=home");
-		}
-		
-		function cancel() {
-            global $db;
-            global $utils;
-            
-            $email_id = $utils->getglobal("email_id");
-            
-            $result = $db->query("select * from emails where id = ".$email_id);
-			
-			if (!$result || !$db->isanyresult())
-				return "Error: Message ".$email_id." does not exists.";
-			
-            $message = $db->fetchrow();
-			
-			$db->query("update emails set is_cancelled = 1 where id = ".$email_id); 
-			
-			$utils->redirect_javascript("?a=home");
-		}
-		
-		function requeue() {
-            global $db;
-            global $utils;
-            
-            $email_id = $utils->getglobal("email_id");
-            
-            $result = $db->query("select * from emails where id = ".$email_id);
-			
-			if (!$result || !$db->isanyresult())
-				return "Error: Message ".$email_id." does not exists.";
-			
-            $message = $db->fetchrow();
-			
-			$db->query("update emails set is_cancelled = 0, is_sent = 0 where id = ".$email_id); 
-			
-			$utils->redirect_javascript("?a=home");
-		}
+        $message = $db->fetchrow();
 
+        // Build attachments info
+        if (!$message["attachments"])
+            $attachmentsInfo = "No attachments";
+        else {
+            $attachments = unserialize($message["attachments"]);
+            foreach ($attachments as $attachment)
+                $attachmentsInfo .= $attachment["path"]."<br>";
+        }
+        
+        $retr .=
+        "
+			<div class=block><a href=\"javascript:history.go(-1);\" class=button>&laquo; back</a></div>
+			<div class=block>
+				<div class=block_title>Message #".$email_id."</div>					
+	  			
+                    <div class=pairs>
+                        <div class=pair>
+                            <div class=key>Foreign id A</div>
+                            <div class=value>".(!$message["foreign_id_a"] ? "none" : $message["foreign_id_a"])."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Foreign id B</div>
+                            <div class=value>".(!$message["foreign_id_b"] ? "none" : $message["foreign_id_b"])."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Priority</div>
+                            <div class=value>".$message["priority"]."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Queued for inmediate sending</div>
+                            <div class=value>".($message["is_inmediate"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Sent</div>
+                            <div class=value>".($message["is_sent"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Cancelled</div>
+                            <div class=value>".($message["is_cancelled"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Blocked</div>
+                            <div class=value>".($message["is_blocked"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Being sent now</div>
+                            <div class=value>".($message["is_sendingnow"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>No. of times sent</div>
+                            <div class=value>".($message["send_count"] ? $message["send_count"]." times" : "not sent")."</div>
+                        </div>
+                    </div>
+                    <div class=pairs>
+                        <div class=pair>
+                            <div class=key>Injected on</div>
+                            <div class=value>".$utils->date_specialformat(strtotime($message["date_injected"]))."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Queued for</div>
+                            <div class=value>".
+                            (
+                                $message["date_queued"]
+                                ?
+                                $utils->date_specialformat(strtotime($message["date_queued"]))
+                                :
+                                "none".($message["is_inmediate"] ? ", queued for inmediate sending" : ", and not queued for inmediate sending")                                
+                            ).
+                            "</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Sent on</div>
+                            <div class=value>".
+                            (
+                                $message["date_sent"]
+                                ?
+                                $utils->date_specialformat(strtotime($message["date_sent"]))
+                                :
+                                "not sent"                                
+                            ).
+                            "</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>HTML format</div>
+                            <div class=value>".($message["is_html"] ? "Yes" : "No")."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>From</div>
+                            <div class=value>".$message["from"].($message["from_name"] ? " [".$message["from_name"]."]" : "")."</div>
+                        </div>
+						<div class=pair>
+                            <div class=key>To</div>
+                            <div class=value>".$message["to"]."</div>
+                        </div>
+						<div class=pair>
+                            <div class=key>Reply to</div>
+                            <div class=value>".
+							(
+								$message["replyto"]
+								?
+								$message["replyto"].($message["replyto_name"] ? " [".$message["replyto_name"]."]" : "")
+								:
+								"none"
+							).
+							"</div>
+                        </div>
+						<div class=pair>
+                            <div class=key>Subject</div>
+                            <div class=value>".$message["subject"]."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Attachments</div>
+                            <div class=value>".$attachmentsInfo."</div>
+                        </div>
+                        <div class=pair>
+                            <div class=key>Embed images</div>
+                            <div class=value>".($message["is_embed_images"] ? "Yes" : "No")."</div>
+                        </div>
+
+                    </div>
+            </div>
+            <iframe class=\"message_preview\" src=\"?a=manager&aa=view_iframe_body&email_id=".$message["id"]."\"></iframe>
+        ";
+        
+        return $retr;
+    }
+    
+    function view_iframe_body() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $db->query("select * from emails where id = ".$email_id);
+        $message = $db->fetchrow();
+        
+        return $message["content"];	
+    }
+	
+	function block() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $result = $db->query("select * from emails where id = ".$email_id);
+		
+		if (!$result || !$db->isanyresult())
+			return "Error: Message ".$email_id." does not exists.";
+		
+        $message = $db->fetchrow();
+		
+		$db->query("update emails set is_blocked = 1 where id = ".$email_id); 
+		
+		$utils->redirect_javascript("?a=home");
+	}
+	
+	function unblock() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $result = $db->query("select * from emails where id = ".$email_id);
+		
+		if (!$result || !$db->isanyresult())
+			return "Error: Message ".$email_id." does not exists.";
+		
+        $message = $db->fetchrow();
+		
+		$db->query("update emails set is_blocked = 0 where id = ".$email_id); 
+		
+		$utils->redirect_javascript("?a=home");
+	}
+	
+	function cancel() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $result = $db->query("select * from emails where id = ".$email_id);
+		
+		if (!$result || !$db->isanyresult())
+			return "Error: Message ".$email_id." does not exists.";
+		
+        $message = $db->fetchrow();
+		
+		$db->query("update emails set is_cancelled = 1 where id = ".$email_id); 
+		
+		$utils->redirect_javascript("?a=home");
+	}
+	
+	function requeue() {
+        global $db;
+        global $utils;
+        
+        $email_id = $utils->getglobal("email_id");
+        
+        $result = $db->query("select * from emails where id = ".$email_id);
+		
+		if (!$result || !$db->isanyresult())
+			return "Error: Message ".$email_id." does not exists.";
+		
+        $message = $db->fetchrow();
+		
+		$db->query("update emails set is_cancelled = 0, is_sent = 0 where id = ".$email_id); 
+		
+		$utils->redirect_javascript("?a=home");
 	}
 
-?>
+}

--- a/classes/messages.class.php
+++ b/classes/messages.class.php
@@ -1,223 +1,221 @@
-<?
+<?php
 
-	class messages {
-		function get_list() {
-		  	global $db;
-		  	global $utils;
-		  	global $html;
-		  	global $now;
-		  	
-		  	if (!$db->isanyresult())
-		  		return false;
-		  	
-		  	$retr .=
-		  	"
-		  		<table class=tableMessages>
-		  		<tr>
-		  			<th>status</th>
-		  			<th>injected on</th>
-		  			<th>priority</th>
-		  			<th>deliver on</th>
-		  			<th>delivered</th>
-		  			<th>to</th>
-		  			<th>subject</th>
-		  			<th>options</th>
-		  		</tr>
-		  	";
-		  	
-		  	while ($row = $db->fetchrow())
-		  		$rows[] = $row;
-		  	
-            foreach ($rows as $row) {
-		  	  	$retr .=
-		  	  	"
-		  	  		<tr>
-		  	  			<td>".
-		  	  			(
-		  	  				$row["is_sendingnow"]
-		  	  				?
-		  	  				"being sent now<br>"
-		  	  				:
-		  	  				""
-		  	  			).
-		  	  			(
-		  	  				$row["send_count"] > 0
-		  	  				?
-		  	  				"delivered ".($row["send_count"] > 1 ? $row["send_count"]." times" : "once")."<br>"
-		  	  				:
-		  	  				(
-		  	  					$row["is_inmediate"]
-		  	  					?
-		  	  					"Inmediate delivery<br>"
-		  	  					:
-                                (
-                                    $row["date_queued"]
-                                    ?
-                                    "scheduled delivery<br>"
-                                    :
-                                    "normal delivery<br>"
-                                ).
-                                "priority ".$row["priority"]
-		  	  				)
-		  	  			).
-		  	  			(
-		  	  				$row["is_cancelled"]
-		  	  				?
-		  	  				"delivery cancelled<br>"
-		  	  				:
-		  	  				""
-		  	  			).
-		  	  			(
-		  	  				$row["is_blocked"]
-		  	  				?
-		  	  				"blocked<br>"
-		  	  				:
-		  	  				""
-		  	  			)
-		  	  			."
-                        </td>		  	  			
-		  	  			<td>".$utils->date_specialformat(strtotime($row["date_injected"]))."</td>
-		  	  			<td>".$row["priority"]."</td>
-		  	  			<td>".
-							(
-								$row["is_inmediate"]
-								?
-								"Inmediately<br>"
-								:
-                                (
-                                    $row["date_queued"]
-                                    ?
-                                    $utils->date_specialformat(strtotime($row["date_queued"]))
-                                    :
-                                    "ASAP<br>"
-                                )
-							).
-							(
-                                $row["is_sent"]
+class messages {
+	function get_list() {
+	  	global $db;
+	  	global $utils;
+	  	global $html;
+	  	global $now;
+	  	
+	  	if (!$db->isanyresult())
+	  		return false;
+	  	
+	  	$retr .=
+	  	"
+	  		<table class=tableMessages>
+	  		<tr>
+	  			<th>status</th>
+	  			<th>injected on</th>
+	  			<th>priority</th>
+	  			<th>deliver on</th>
+	  			<th>delivered</th>
+	  			<th>to</th>
+	  			<th>subject</th>
+	  			<th>options</th>
+	  		</tr>
+	  	";
+	  	
+	  	while ($row = $db->fetchrow())
+	  		$rows[] = $row;
+	  	
+        foreach ($rows as $row) {
+	  	  	$retr .=
+	  	  	"
+	  	  		<tr>
+	  	  			<td>".
+	  	  			(
+	  	  				$row["is_sendingnow"]
+	  	  				?
+	  	  				"being sent now<br>"
+	  	  				:
+	  	  				""
+	  	  			).
+	  	  			(
+	  	  				$row["send_count"] > 0
+	  	  				?
+	  	  				"delivered ".($row["send_count"] > 1 ? $row["send_count"]." times" : "once")."<br>"
+	  	  				:
+	  	  				(
+	  	  					$row["is_inmediate"]
+	  	  					?
+	  	  					"Inmediate delivery<br>"
+	  	  					:
+                            (
+                                $row["date_queued"]
                                 ?
-                                "Already delivered<br>"
+                                "scheduled delivery<br>"
                                 :
-                                ""
+                                "normal delivery<br>"
+                            ).
+                            "priority ".$row["priority"]
+	  	  				)
+	  	  			).
+	  	  			(
+	  	  				$row["is_cancelled"]
+	  	  				?
+	  	  				"delivery cancelled<br>"
+	  	  				:
+	  	  				""
+	  	  			).
+	  	  			(
+	  	  				$row["is_blocked"]
+	  	  				?
+	  	  				"blocked<br>"
+	  	  				:
+	  	  				""
+	  	  			)
+	  	  			."
+                    </td>		  	  			
+	  	  			<td>".$utils->date_specialformat(strtotime($row["date_injected"]))."</td>
+	  	  			<td>".$row["priority"]."</td>
+	  	  			<td>".
+						(
+							$row["is_inmediate"]
+							?
+							"Inmediately<br>"
+							:
+                            (
+                                $row["date_queued"]
+                                ?
+                                $utils->date_specialformat(strtotime($row["date_queued"]))
+                                :
+                                "ASAP<br>"
+                            )
+						).
+						(
+                            $row["is_sent"]
+                            ?
+                            "Already delivered<br>"
+                            :
+                            ""
+						).
+						(
+							$row["is_blocked"]
+							?
+							"blocked<br>"
+							:
+							""
+						).
+						(
+							$row["is_cancelled"]
+							?
+							"cancelled"
+							:
+							""
+						).
+					"</td>
+	  	  			<td>".
+						(
+							!$row["send_count"]
+							?
+							"not yet delivered"
+							:
+							$utils->date_specialformat(strtotime($row["date_sent"])).
+							(
+								$row["send_count"] > 0
+								?
+								"<br>delivered ".($row["send_count"] > 1 ? $row["send_count"]." times" : "once")
+								:
+								""
+							)
+						).
+					"</td>
+	  	  			<td>".$row["to"]."</td>
+	  	  			<td>".$utils->cuttext($row["subject"], 50, " ...")."</td>
+	  	  			<td class=buttons>
+							<a href=\"?a=manager&aa=view&email_id=".$row["id"]."\" class=button>view</a>
+							".
+							(
+								!$row["is_sent"]
+								&&
+								!$row["is_sendingnow"]
+								&&
+								!$row["is_cancelled"]
+								&&
+								!$row["is_blocked"]
+								?
+								"<a href=\"javascript:confirmation('are you sure you want to BLOCK this message?', '?a=manager&aa=block&email_id=".$row["id"]."');\" class=button>block</a> "
+								:
+								""
 							).
 							(
+								!$row["is_sent"]
+								&&
 								$row["is_blocked"]
 								?
-								"blocked<br>"
+								"<a href=\"?a=manager&aa=unblock&email_id=".$row["id"]."\" class=button>unblock</a> "
 								:
 								""
 							).
 							(
-								$row["is_cancelled"]
+								!$row["is_sent"]
+								&&
+								!$row["is_sendingnow"]
+								&&
+								!$row["is_cancelled"]
+								&&
+								!$row["is_blocked"]
 								?
-								"cancelled"
+								"<a href=\"javascript:confirmation('are you sure you want to CANCEL this message?', '?a=manager&aa=cancel&email_id=".$row["id"]."');\" class=button>cancel</a> "
 								:
 								""
 							).
-						"</td>
-		  	  			<td>".
 							(
-								!$row["send_count"]
-								?
-								"not yet delivered"
-								:
-								$utils->date_specialformat(strtotime($row["date_sent"])).
+								!$row["is_sendingnow"]
+								&&
+								!$row["is_blocked"]
+								&&
 								(
-									$row["send_count"] > 0
-									?
-									"<br>delivered ".($row["send_count"] > 1 ? $row["send_count"]." times" : "once")
-									:
-									""
+									(!$row["is_sent"] && $row["is_cancelled"])
+									||
+									$row["is_sent"]
 								)
+								?
+								"<a href=\"javascript:confirmation('are you sure you want to REQUEUE this message for inmediate delivery? It will be sent again', '?a=manager&aa=requeue&email_id=".$row["id"]."');\" class=button>requeue</a> "
+								:
+								""
 							).
-						"</td>
-		  	  			<td>".$row["to"]."</td>
-		  	  			<td>".$utils->cuttext($row["subject"], 50, " ...")."</td>
-		  	  			<td class=buttons>
-								<a href=\"?a=manager&aa=view&email_id=".$row["id"]."\" class=button>view</a>
-								".
-								(
-									!$row["is_sent"]
-									&&
-									!$row["is_sendingnow"]
-									&&
-									!$row["is_cancelled"]
-									&&
-									!$row["is_blocked"]
-									?
-									"<a href=\"javascript:confirmation('are you sure you want to BLOCK this message?', '?a=manager&aa=block&email_id=".$row["id"]."');\" class=button>block</a> "
-									:
-									""
-								).
-								(
-									!$row["is_sent"]
-									&&
-									$row["is_blocked"]
-									?
-									"<a href=\"?a=manager&aa=unblock&email_id=".$row["id"]."\" class=button>unblock</a> "
-									:
-									""
-								).
-								(
-									!$row["is_sent"]
-									&&
-									!$row["is_sendingnow"]
-									&&
-									!$row["is_cancelled"]
-									&&
-									!$row["is_blocked"]
-									?
-									"<a href=\"javascript:confirmation('are you sure you want to CANCEL this message?', '?a=manager&aa=cancel&email_id=".$row["id"]."');\" class=button>cancel</a> "
-									:
-									""
-								).
-								(
-									!$row["is_sendingnow"]
-									&&
-									!$row["is_blocked"]
-									&&
-									(
-										(!$row["is_sent"] && $row["is_cancelled"])
-										||
-										$row["is_sent"]
-									)
-									?
-									"<a href=\"javascript:confirmation('are you sure you want to REQUEUE this message for inmediate delivery? It will be sent again', '?a=manager&aa=requeue&email_id=".$row["id"]."');\" class=button>requeue</a> "
-									:
-									""
-								).
-								"
-		  	  			</td>
-		  	  		</tr>
-		  	  	";
-		  	  	
-		  	  	$db->query("
-		  	  		select			*
-		  	  		from			incidences
-		  	  		where			email_id = ".$row["id"]."
-		  	  		order by		date_incidence asc
-		  	  	");
+							"
+	  	  			</td>
+	  	  		</tr>
+	  	  	";
+	  	  	
+	  	  	$db->query("
+	  	  		select			*
+	  	  		from			incidences
+	  	  		where			email_id = ".$row["id"]."
+	  	  		order by		date_incidence asc
+	  	  	");
 
-		  	  	if ($db->isanyresult()) {
-		  	  		while ($incidence = $db->fetchrow()) {
-			  	  		$retr .=
-			  	  		"
-			  	  			<tr>
-			  	  				<td></td>
-			  	  				<td>".$utils->date_specialformat(strtotime($incidence["date_incidence"]))."</td>
-			  	  				<td colspan=5><img src=gfx/img/warning.gif align=absmiddle> ".$incidence["description"]."</td>
-			  	  			</tr>
-			  	  		";
-			  	  	}
+	  	  	if ($db->isanyresult()) {
+	  	  		while ($incidence = $db->fetchrow()) {
+		  	  		$retr .=
+		  	  		"
+		  	  			<tr>
+		  	  				<td></td>
+		  	  				<td>".$utils->date_specialformat(strtotime($incidence["date_incidence"]))."</td>
+		  	  				<td colspan=5><img src=gfx/img/warning.gif align=absmiddle> ".$incidence["description"]."</td>
+		  	  			</tr>
+		  	  		";
 		  	  	}
-		 	}
-		 	
-		 	$retr .=
-		 	"
-		 		</table>
-		 	";			
-			
-			return $retr;
-		}
+	  	  	}
+	 	}
+	 	
+	 	$retr .=
+	 	"
+	 		</table>
+	 	";			
+		
+		return $retr;
 	}
-
-?>
+}

--- a/classes/out.class.php
+++ b/classes/out.class.php
@@ -1,24 +1,22 @@
-<?
+<?php
 
-	class out {
-		var $data;
+class out {
+	var $data;
 
-		function add($data) {
-			$this->data .= $data;
-		}
-
-		function add_tobeggining($data) {
-			$this->data = $data.$this->data;
-		}
-
-		function clear() {
-			$this->data = "";
-		}
-
-		function dump() {
-			echo $this->data;
-		}
-
+	function add($data) {
+		$this->data .= $data;
 	}
 
-?>
+	function add_tobeggining($data) {
+		$this->data = $data.$this->data;
+	}
+
+	function clear() {
+		$this->data = "";
+	}
+
+	function dump() {
+		echo $this->data;
+	}
+
+}

--- a/classes/utils.class.php
+++ b/classes/utils.class.php
@@ -1,92 +1,91 @@
-<?
-	class utils {
-		function getglobal($var) {
-			if(isset($GLOBALS[$var]))
-				return $GLOBALS[$var];
-			else
-			if(isset($_POST[$var]))
-				return $_POST[$var];
-			else
-			if(isset($_GET[$var]))
-				return $_GET[$var];
-			else
-				return false;
-		}
+<?php
+class utils {
+	function getglobal($var) {
+		if(isset($GLOBALS[$var]))
+			return $GLOBALS[$var];
+		else
+		if(isset($_POST[$var]))
+			return $_POST[$var];
+		else
+		if(isset($_GET[$var]))
+			return $_GET[$var];
+		else
+			return false;
+	}
 
-		function secondstohumantime($seconds) {
-			$minutes = floor($seconds / 60);
+	function secondstohumantime($seconds) {
+		$minutes = floor($seconds / 60);
 
-			if ($minutes > 0) {
-				$seconds = $seconds - ($minutes * 60);
+		if ($minutes > 0) {
+			$seconds = $seconds - ($minutes * 60);
 
-				$hours = floor($minutes / 60);
+			$hours = floor($minutes / 60);
 
-				if ($hours > 0) {
-					$minutes = $minutes - ($hours * 60);
+			if ($hours > 0) {
+				$minutes = $minutes - ($hours * 60);
 
-					$days = floor($hours / 24);
+				$days = floor($hours / 24);
 
-					if ($days > 0) {
-						$hours = $hours - ($days * 24);
-						return $days." day".($days > 1 ? "s" : "").", ".$this->addzeros($hours, 2).":".$this->addzeros($minutes, 2).".".$this->addzeros($seconds, 2);
-					}
-					else
-						return $this->addzeros($hours, 2).":".$this->addzeros($minutes, 2).".".$this->addzeros($seconds, 2);
+				if ($days > 0) {
+					$hours = $hours - ($days * 24);
+					return $days." day".($days > 1 ? "s" : "").", ".$this->addzeros($hours, 2).":".$this->addzeros($minutes, 2).".".$this->addzeros($seconds, 2);
 				}
 				else
-					return $this->addzeros($minutes, 2)." min. ".$this->addzeros($seconds, 2)." sec.";
+					return $this->addzeros($hours, 2).":".$this->addzeros($minutes, 2).".".$this->addzeros($seconds, 2);
 			}
 			else
-				return $this->addzeros($seconds, 2)." sec.";
+				return $this->addzeros($minutes, 2)." min. ".$this->addzeros($seconds, 2)." sec.";
 		}
-
-		function addzeros($string, $totalchars) {
-			if (strlen($string) < $totalchars)
-				return str_repeat("0", ($totalchars-strlen($string))).$string;
-			else
-				return $string;
-		}
-
-		function cuttext($string, $cutat, $finalstring = "") {
-			$string = strip_tags($string);
-
-			if (strlen($string) < $cutat)
-				return $string;
-
-			if (!$nextspace = strpos($string, " ", $cutat))
-				return substr($string, 0, $cutat).$finalstring;
-			else
-				return substr($string, 0, $nextspace).$finalstring;
-		}
-
-		function date_specialformat($time, $is_ago_remaining = true) {
-			$retr .= "<b>".date("H:i.s", $time)."</b>";
-			// If it's today
-			if(date("j/n/Y", $time) == date("j/n/Y"))	
-				$retr .= " today";
-			else
-			if(date("j/n/Y", $time) == date("j/n/Y", mktime()-(24*60*60)))
-				$retr .= " yesterday";
-			else
-			if(date("j/n/Y", $time) == date("j/n/Y", mktime()+(24*60*60)))
-				$retr .= " tomorrow";
-			else
-				$retr .= " ".date("j/n/y", $time);
-
-			if ($is_ago_remaining) {
-				if($time < mktime())
-					$retr .= " / ".$this->secondstohumantime(mktime() - $time)." ago";
-				else
-					$retr .= " / ".$this->secondstohumantime($time - mktime())." remaining";
-			}
-
-			return $retr;
-		}
-
-		function redirect_javascript($url) {
-			echo "<script language=javascript>document.location='".$url."';</script>";
-		}
-
-
+		else
+			return $this->addzeros($seconds, 2)." sec.";
 	}
-?>
+
+	function addzeros($string, $totalchars) {
+		if (strlen($string) < $totalchars)
+			return str_repeat("0", ($totalchars-strlen($string))).$string;
+		else
+			return $string;
+	}
+
+	function cuttext($string, $cutat, $finalstring = "") {
+		$string = strip_tags($string);
+
+		if (strlen($string) < $cutat)
+			return $string;
+
+		if (!$nextspace = strpos($string, " ", $cutat))
+			return substr($string, 0, $cutat).$finalstring;
+		else
+			return substr($string, 0, $nextspace).$finalstring;
+	}
+
+	function date_specialformat($time, $is_ago_remaining = true) {
+		$retr .= "<b>".date("H:i.s", $time)."</b>";
+		// If it's today
+		if(date("j/n/Y", $time) == date("j/n/Y"))	
+			$retr .= " today";
+		else
+		if(date("j/n/Y", $time) == date("j/n/Y", mktime()-(24*60*60)))
+			$retr .= " yesterday";
+		else
+		if(date("j/n/Y", $time) == date("j/n/Y", mktime()+(24*60*60)))
+			$retr .= " tomorrow";
+		else
+			$retr .= " ".date("j/n/y", $time);
+
+		if ($is_ago_remaining) {
+			if($time < mktime())
+				$retr .= " / ".$this->secondstohumantime(mktime() - $time)." ago";
+			else
+				$retr .= " / ".$this->secondstohumantime($time - mktime())." remaining";
+		}
+
+		return $retr;
+	}
+
+	function redirect_javascript($url) {
+		echo "<script language=javascript>document.location='".$url."';</script>";
+	}
+
+
+}

--- a/common.inc.php
+++ b/common.inc.php
@@ -1,112 +1,110 @@
-<?
+<?php
 
-	define("VERSION", "3.1b");
-	define("OFFICIAL_PAGE_URL", "https://github.com/tin-cat/emailqueue");
+define("VERSION", "3.1b");
+define("OFFICIAL_PAGE_URL", "https://github.com/tin-cat/emailqueue");
 
-	include APP_DIR."config/db.config.inc.php";
-	include APP_DIR."config/application.config.inc.php";
-	
-	date_default_timezone_set(DEFAULT_TIMEZONE);
-	
-	$now = mktime();
-	
-	include LIB_DIR."/database/database.inc.php";
-	include LIB_DIR."/database/dbsource_mysqli.inc.php";
-	$db = new dbsource_mysqli(DB_HOST, DB_UID, DB_PWD, DB_DATABASE);
-	if (!$db->connect()) {
-		echo "Cannot connect to database";
-		die;
-	}
-	
-	$db->query("set names UTF8");
-	
-	include "classes/out.class.php";
-	$out = new out();
-	
-	include "classes/html.class.php";
-	$html = new html();
-	
-	include "classes/utils.class.php";
-	$utils = new utils();
-	
-	include "classes/messages.class.php";
-	$messages = new messages();
+include APP_DIR."config/db.config.inc.php";
+include APP_DIR."config/application.config.inc.php";
 
-	include "classes/logger.class.php";
-	$logger = new logger();
-	
-	function checkemail($email) {
-        return preg_match("/^[.\w-]+@([\w-]+\.)+[a-zA-Z]{2,15}$/", $email);
-	}
-	
-	function add_incidence($email_id, $description) {
-		global $db;
-		
-		$db->query
-		("
-			insert			into incidences
-			(
-				email_id,
-				date_incidence,
-				description
-			)
-			values
-			(
-				".$email_id.",
-				'".date("Y-n-j H:i:s")."',
-				'".$db->safestring($description)."'
-			)
-		");
-	}
-	
-	function mark_as_sent($email_id) {
-		global $db;		
-		$db->query("update emails set is_sent = 1 where id = ".$email_id);
-	}
-	
-	function cancel($email_id) {
-		global $db;		
-		$db->query("update emails set is_cancelled = 1 where id = ".$email_id);
-	}
-	
-	function uncancel($email_id) {
-		global $db;		
-		$db->query("update emails set is_cancelled = 0 where id = ".$email_id);
-	}
-	
-	function block($email_id) {
-		global $db;		
-		$db->query("update emails set is_blocked = 1 where id = ".$email_id);
-	}
-	
-	function unblock($email_id) {
-		global $db;		
-		$db->query("update emails set is_blocked = 0 where id = ".$email_id);
-	}
-	
-	function setsendingnow($email_id) {
-		global $db;		
-		$db->query("update emails set is_sendingnow = 1 where id = ".$email_id);
-	}
-	
-	function unsetsendingnow($email_id) {
-		global $db;		
-		$db->query("update emails set is_sendingnow = 0 where id = ".$email_id);
-	}
+date_default_timezone_set(DEFAULT_TIMEZONE);
 
-	function update_send_count($email_id, $count) {
-		global $db;		
-		$db->query("update emails set send_count = ".$count." where id = ".$email_id);
-	}
-	
-	function update_error_count($email_id, $count) {
-		global $db;		
-		$db->query("update emails set error_count = ".$count." where id = ".$email_id);
-	}
-	
-	function update_sentdate($email_id, $timestamp) {
-		global $db;		
-		$db->query("update emails set date_sent = '".date("Y-n-j H:i:s", $timestamp)."' where id = ".$email_id);
-	}
+$now = mktime();
 
-?>
+include LIB_DIR."/database/database.inc.php";
+include LIB_DIR."/database/dbsource_mysqli.inc.php";
+$db = new dbsource_mysqli(DB_HOST, DB_UID, DB_PWD, DB_DATABASE);
+if (!$db->connect()) {
+	echo "Cannot connect to database";
+	die;
+}
+
+$db->query("set names UTF8");
+
+include "classes/out.class.php";
+$out = new out();
+
+include "classes/html.class.php";
+$html = new html();
+
+include "classes/utils.class.php";
+$utils = new utils();
+
+include "classes/messages.class.php";
+$messages = new messages();
+
+include "classes/logger.class.php";
+$logger = new logger();
+
+function checkemail($email) {
+    return preg_match("/^[.\w-]+@([\w-]+\.)+[a-zA-Z]{2,15}$/", $email);
+}
+
+function add_incidence($email_id, $description) {
+	global $db;
+	
+	$db->query
+	("
+		insert			into incidences
+		(
+			email_id,
+			date_incidence,
+			description
+		)
+		values
+		(
+			".$email_id.",
+			'".date("Y-n-j H:i:s")."',
+			'".$db->safestring($description)."'
+		)
+	");
+}
+
+function mark_as_sent($email_id) {
+	global $db;		
+	$db->query("update emails set is_sent = 1 where id = ".$email_id);
+}
+
+function cancel($email_id) {
+	global $db;		
+	$db->query("update emails set is_cancelled = 1 where id = ".$email_id);
+}
+
+function uncancel($email_id) {
+	global $db;		
+	$db->query("update emails set is_cancelled = 0 where id = ".$email_id);
+}
+
+function block($email_id) {
+	global $db;		
+	$db->query("update emails set is_blocked = 1 where id = ".$email_id);
+}
+
+function unblock($email_id) {
+	global $db;		
+	$db->query("update emails set is_blocked = 0 where id = ".$email_id);
+}
+
+function setsendingnow($email_id) {
+	global $db;		
+	$db->query("update emails set is_sendingnow = 1 where id = ".$email_id);
+}
+
+function unsetsendingnow($email_id) {
+	global $db;		
+	$db->query("update emails set is_sendingnow = 0 where id = ".$email_id);
+}
+
+function update_send_count($email_id, $count) {
+	global $db;		
+	$db->query("update emails set send_count = ".$count." where id = ".$email_id);
+}
+
+function update_error_count($email_id, $count) {
+	global $db;		
+	$db->query("update emails set error_count = ".$count." where id = ".$email_id);
+}
+
+function update_sentdate($email_id, $timestamp) {
+	global $db;		
+	$db->query("update emails set date_sent = '".date("Y-n-j H:i:s", $timestamp)."' where id = ".$email_id);
+}

--- a/config/application.config.inc.php.example
+++ b/config/application.config.inc.php.example
@@ -1,37 +1,37 @@
-<?
-	define("FRONTEND_USER", "user"); // The user name for the frontend
-	define("FRONTEND_PASSWORD", "password"); // The password for the frontend
+<?php
 
-	define("QUEUED_MESSAGES", 40); // Number of last queued messages to show in frontend
-	define("LATEST_DELIVERED_MESSAGES", 10); // Number of last delivered messages to show in frontend
-	define("LATEST_CANCELLED_MESSAGES", 10); // Number of last cancelled messages to show in frontend
-	define("MAXIMUM_DELIVERY_TIMEOUT", 50); // Maximum seconds Emailqueue should spend sending queued emails everytime it's called. Keep this smaller than the amount of time between calls to the delivery script (e.g. If you're calling delivery every 60 seconds, keep this at something like 50 to avoid accumulating instances of Emailqueue eating resources)
-	define("DELIVERY_INTERVAL", 10); // Hundredths of a second between each email send. Use this to be more friendly to SMTP servers, should be a balance between being friendly and the number of emails you need to send per seconds in order to keep your queue clean.
-	define("MAX_DELIVERS_A_TIME", 1000); // Number of maximum messages to deliver every time delivery script is called. Anyway, this is better controlled with the MAXIMUM_DELIVERY_TIMEOUT configuration above.
-	define("SENDING_RETRY_MAX_ATTEMPTS", 3); // Maximum number of attemps to send a message if error is found.
-	define("PURGE_OLDER_THAN_DAYS", 5); // Purge messages older than this days from the database. Depending on the amount of emails you send, use this setting to keep your sent emails database to grow too big. It should be a balance between how big would you like to keep your sent emails history and how responsive would you like emailqueue to be. Smaller database will make emailqueue run faster when specially inserting new emails.
-	
-	define("SEND_METHOD", "smtp"); // Set it to either "smtp" or "sendmail" to choose the method for delivering emails. If "smtp" is choosen, at least the SMTP_SERVER below must be set.
-	define("SMTP_SERVER", "127.0.0.1"); // The IP of the SMTP server
-	define("SMTP_PORT", 25); // The port of the SMTP server
-	define("SMTP_IS_AUTHENTICATION", false); // True to use SMTP server Authentication
-	define("SMTP_AUTHENTICATION_USERNAME", "");
-	define("SMTP_AUTHENTICATION_PASSWORD", "");
-	
-	define("CHARSET", "utf-8"); //Used in Content-Type Email Header
-	define("CONTENT_TRANSFER_ENCODING", "8bit"); //Content-Transfer-Encoding Email Header. May be 7bit, 8bit, quoted-printable or base64
+define("FRONTEND_USER", "user"); // The user name for the frontend
+define("FRONTEND_PASSWORD", "password"); // The password for the frontend
 
-	define("PHPMAILER_LANGUAGE", "en");
-	
-	define("DEFAULT_TIMEZONE", "UTC");
+define("QUEUED_MESSAGES", 40); // Number of last queued messages to show in frontend
+define("LATEST_DELIVERED_MESSAGES", 10); // Number of last delivered messages to show in frontend
+define("LATEST_CANCELLED_MESSAGES", 10); // Number of last cancelled messages to show in frontend
+define("MAXIMUM_DELIVERY_TIMEOUT", 50); // Maximum seconds Emailqueue should spend sending queued emails everytime it's called. Keep this smaller than the amount of time between calls to the delivery script (e.g. If you're calling delivery every 60 seconds, keep this at something like 50 to avoid accumulating instances of Emailqueue eating resources)
+define("DELIVERY_INTERVAL", 10); // Hundredths of a second between each email send. Use this to be more friendly to SMTP servers, should be a balance between being friendly and the number of emails you need to send per seconds in order to keep your queue clean.
+define("MAX_DELIVERS_A_TIME", 1000); // Number of maximum messages to deliver every time delivery script is called. Anyway, this is better controlled with the MAXIMUM_DELIVERY_TIMEOUT configuration above.
+define("SENDING_RETRY_MAX_ATTEMPTS", 3); // Maximum number of attemps to send a message if error is found.
+define("PURGE_OLDER_THAN_DAYS", 5); // Purge messages older than this days from the database. Depending on the amount of emails you send, use this setting to keep your sent emails database to grow too big. It should be a balance between how big would you like to keep your sent emails history and how responsive would you like emailqueue to be. Smaller database will make emailqueue run faster when specially inserting new emails.
 
-	define("LOGS_DIR", "logs"); // The directory to store logs
-	define("LOGS_FILENAME_DATEFORMAT", "Y-m-d"); // The file name format for log files, as a parameter for the PHP date() function
-	define("LOGS_DATA_DATEFORMAT", "Y-m-d H:i:s"); // The format of the date as stored inside log files, as a parameter for the PHP date() function
+define("SEND_METHOD", "smtp"); // Set it to either "smtp" or "sendmail" to choose the method for delivering emails. If "smtp" is choosen, at least the SMTP_SERVER below must be set.
+define("SMTP_SERVER", "127.0.0.1"); // The IP of the SMTP server
+define("SMTP_PORT", 25); // The port of the SMTP server
+define("SMTP_IS_AUTHENTICATION", false); // True to use SMTP server Authentication
+define("SMTP_AUTHENTICATION_USERNAME", "");
+define("SMTP_AUTHENTICATION_PASSWORD", "");
 
-    define("IS_DEVEL_ENVIRONMENT", true); // When set to true, only emails addressed to emails into $devel_emails array are sent
+define("CHARSET", "utf-8"); //Used in Content-Type Email Header
+define("CONTENT_TRANSFER_ENCODING", "8bit"); //Content-Transfer-Encoding Email Header. May be 7bit, 8bit, quoted-printable or base64
 
-    $devel_emails = array(
-        "me@email.com"
-    );
-?>
+define("PHPMAILER_LANGUAGE", "en");
+
+define("DEFAULT_TIMEZONE", "UTC");
+
+define("LOGS_DIR", "logs"); // The directory to store logs
+define("LOGS_FILENAME_DATEFORMAT", "Y-m-d"); // The file name format for log files, as a parameter for the PHP date() function
+define("LOGS_DATA_DATEFORMAT", "Y-m-d H:i:s"); // The format of the date as stored inside log files, as a parameter for the PHP date() function
+
+define("IS_DEVEL_ENVIRONMENT", true); // When set to true, only emails addressed to emails into $devel_emails array are sent
+
+$devel_emails = array(
+    "me@email.com"
+);

--- a/config/db.config.inc.php.example
+++ b/config/db.config.inc.php.example
@@ -1,8 +1,6 @@
-<?
+<?php
 
 	define("DB_HOST", "127.0.0.1");
 	define("DB_UID", "username");
 	define("DB_PWD", "password");
 	define("DB_DATABASE", "emailqueue");
-
-?>

--- a/example.php
+++ b/example.php
@@ -3,7 +3,7 @@
 <body>
 EMailqeue - PHP Inject class test
 <hr>
-<?
+<?php
 
     define("EMAILQUEUE_DIR", "./"); // Setup where emailqueue resides
 

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -1,54 +1,52 @@
-<?
+<?php
 
-	/*
-		EMailqueue
-		Frontend component
-	*/
-	
-	define("LIB_DIR", "lib");
-	define("APP_DIR", "../");
-	
-	include APP_DIR."common.inc.php";
+/*
+	EMailqueue
+	Frontend component
+*/
 
-	if (!($_SERVER['PHP_AUTH_USER'] == FRONTEND_USER && $_SERVER['PHP_AUTH_PW'] == FRONTEND_PASSWORD)) {
-		header("WWW-Authenticate: Basic realm=\"Emailqueue frontend\"");
-		header("HTTP/1.0 401 Unauthorized");
-		echo "Access restricted";
-		exit;
-	}
-	
-	$a = $utils->getglobal("a");
-	if (!$a || $a == "")
-		$a = "home";
-	
-	switch ($a) {
-		case "home":
-			include APP_DIR."classes/home.class.php";
-			$home = new home();
-			$out->add($home->getinfo());
-			break;
-		
-		case "manager":
-            include APP_DIR."classes/manager.class.php";
-            $manager = new manager();
-            $out->add($manager->run());
-            break;
+define("LIB_DIR", "lib");
+define("APP_DIR", "../");
 
-		case "servicetools":
-			include APP_DIR."classes/servicetools.class.php";
-			$servicetools = new servicetools();
-			$out->add($servicetools->run());
-			break;
-	}
-	
-	// Control cases wich don't need head nor footer
-	if ($utils->getglobal("aa") != "view_iframe_body") {
-	   $out->add_tobeggining($html->head());
-	   $out->add($html->foot());
-	}
-	
-	$out->dump();
-	
-	$db->disconnect();
+include APP_DIR."common.inc.php";
 
-?>
+if (!($_SERVER['PHP_AUTH_USER'] == FRONTEND_USER && $_SERVER['PHP_AUTH_PW'] == FRONTEND_PASSWORD)) {
+	header("WWW-Authenticate: Basic realm=\"Emailqueue frontend\"");
+	header("HTTP/1.0 401 Unauthorized");
+	echo "Access restricted";
+	exit;
+}
+
+$a = $utils->getglobal("a");
+if (!$a || $a == "")
+	$a = "home";
+
+switch ($a) {
+	case "home":
+		include APP_DIR."classes/home.class.php";
+		$home = new home();
+		$out->add($home->getinfo());
+		break;
+	
+	case "manager":
+        include APP_DIR."classes/manager.class.php";
+        $manager = new manager();
+        $out->add($manager->run());
+        break;
+
+	case "servicetools":
+		include APP_DIR."classes/servicetools.class.php";
+		$servicetools = new servicetools();
+		$out->add($servicetools->run());
+		break;
+}
+
+// Control cases wich don't need head nor footer
+if ($utils->getglobal("aa") != "view_iframe_body") {
+   $out->add_tobeggining($html->head());
+   $out->add($html->foot());
+}
+
+$out->dump();
+
+$db->disconnect();

--- a/lib/database/database.inc.php
+++ b/lib/database/database.inc.php
@@ -1,92 +1,90 @@
-<?
+<?php
 
-	/*
-		Basic version with minimum functionalities
-	*/
+/*
+	Basic version with minimum functionalities
+*/
 
-	class dbsource
+class dbsource
+{
+	var $type;
+	var $connectionid;
+	var $result;
+	var $row;
+
+	var $is_debug = true;
+
+	function dbsource($type)
 	{
-		var $type;
-		var $connectionid;
-		var $result;
-		var $row;
-
-		var $is_debug = true;
-
-		function dbsource($type)
+		$this->type	= $type;
+	}
+	
+	function query($query)
+	{
+		$this->is_cached = false;
+		$this->last_query = $query;
+		return true;
+	}
+	
+	function isanyresult()
+	{
+		if(!$this->is_cached)
+			return $this->run_isanyresult();
+		else
 		{
-			$this->type	= $type;
-		}
-		
-		function query($query)
-		{
-			$this->is_cached = false;
-			$this->last_query = $query;
-			return true;
-		}
-		
-		function isanyresult()
-		{
-			if(!$this->is_cached)
-				return $this->run_isanyresult();
+			if(is_array($this->rows))
+				return true;
 			else
+				return false;
+		}
+	}
+	
+	function countrows()
+	{
+		if(!$this->is_cached)
+			return $this->run_countrows();
+		else
+			return count($this->rows);
+	}
+	
+	function seek_row($numrow)
+	{
+		if(!$this->is_cached)
+			return $this->run_seek_row($numrow);				
+		else
+		{
+			if(is_array($this->rows))
 			{
-				if(is_array($this->rows))
-					return true;
-				else
-					return false;
-			}
-		}
-		
-		function countrows()
-		{
-			if(!$this->is_cached)
-				return $this->run_countrows();
-			else
-				return count($this->rows);
-		}
-		
-		function seek_row($numrow)
-		{
-			if(!$this->is_cached)
-				return $this->run_seek_row($numrow);				
-			else
-			{
-				if(is_array($this->rows))
-				{
-					// Ugly and slow way to seek a position into an array when the results are cached!
-					reset($this->rows);
-					for($i=0; $i<$numrow; $i++)
-						next($this->rows);
-				}
-			}
-		}
-		
-		function fetchrow()
-		{
-			if(!$this->is_cached)
-				return $this->run_fetchrow();
-			else
-			{
-				if(is_array($this->rows))
-				{
-					$this->row = current($this->rows);
+				// Ugly and slow way to seek a position into an array when the results are cached!
+				reset($this->rows);
+				for($i=0; $i<$numrow; $i++)
 					next($this->rows);
-					return $this->row;
-				}
-				else
-					return false;
-			}		
+			}
 		}
-		
-		function free()
+	}
+	
+	function fetchrow()
+	{
+		if(!$this->is_cached)
+			return $this->run_fetchrow();
+		else
 		{
-			if(!$this->is_cached)
-				return $this->run_free();
+			if(is_array($this->rows))
+			{
+				$this->row = current($this->rows);
+				next($this->rows);
+				return $this->row;
+			}
 			else
-				unset($this->rows);
-		}
-
+				return false;
+		}		
+	}
+	
+	function free()
+	{
+		if(!$this->is_cached)
+			return $this->run_free();
+		else
+			unset($this->rows);
 	}
 
-?>
+}

--- a/lib/database/dbsource_mysql.inc.php
+++ b/lib/database/dbsource_mysql.inc.php
@@ -1,116 +1,114 @@
-<?
-		
-  	class dbsource_mysql extends dbsource
+<?php
+	
+	class dbsource_mysql extends dbsource
+{
+	var $host;
+	var $uid;
+	var $pwd;
+	var $database;
+	var $connectionid;
+
+	function dbsource_mysql ($host, $uid, $pwd, $database = "", $avoidpersistence = false)
 	{
-		var $host;
-		var $uid;
-		var $pwd;
-		var $database;
-		var $connectionid;
-
-		function dbsource_mysql ($host, $uid, $pwd, $database = "", $avoidpersistence = false)
-		{
-			$this->dbsource ("mysql");
-			$this->host = $host;
-			$this->uid = $uid;
-			$this->pwd = $pwd;
-			$this->database	= $database;
-			$this->avoidpersistence = $avoidpersistence;
-		}
-
-		function connect($select = true)
-		{
-			$this->connectionid = mysql_connect ($this->host, $this->uid, $this->pwd, $this->avoidpersistence);
-			if($select)
-				$this->select($this->database);
-			return $this->connectionid;
-		}
-
-		function select($database)
-		{
-			mysql_select_db($database);
-		}
-
-		function disconnect ()
-		{
-			mysql_close ($this->connectionid);
-		}
-
-		function query ($sql)
-		{
-            $this->last_query = $sql;
-            		
-			$this->result = mysql_query ($sql, $this->connectionid);
-			
-			return $this->result;
-		}
-   
-		function free ()
-		{
-			mysql_free_result ($this->result);
-		}
-
-		function isanyresult ()
-		{
-			return mysql_affected_rows ($this->connectionid);
-		}
-
-		function fetchrow ()
-		{
-			$this->row = mysql_fetch_assoc ($this->result);
-			return $this->row;
-		}
-
-		function getfield ($field)
-		{
-			return $this->row[$field];
-		}
-
-		function countrows ()
-		{
-			return mysql_num_rows ($this->result);
-		}
-		
-		function seek_row($numrow)
-		{
-            return mysql_data_seek($this->result, $numrow);
-		}
-   
-		function getinsertid ()
-		{
-			return mysql_insert_id ($this->connectionid);
-		}
-		
-		function get_errno()
-		{
-		  return mysql_errno($this->connectionid);
-		}
-		
-		function get_err()
-		{
-		  return mysql_error($this->connectionid);
-		}
-		
-		function dump_error()
-		{
-			$bt = debug_backtrace();
-            return
-				"<div style=\"margin: 5px; padding: 5px; background: #fe0; color: #444;\">".
-					"MySQL Error: (".$this->get_errno().")".$this->get_err()."<br>".
-					"Query: \"".$this->last_query."\"<br>".
-					($bt[1] ? "Backtrace file #1: ".$bt[1]["file"]." (line ".$bt[1]["line"].")<br>" : null).
-					($bt[2] ? "Backtrace file #2: ".$bt[2]["file"]." (line ".$bt[2]["line"].")<br>" : null).
-					($bt[3] ? "Backtrace file #3: ".$bt[3]["file"]." (line ".$bt[3]["line"].")<br>" : null).
-					($bt[4] ? "Backtrace file #3: ".$bt[4]["file"]." (line ".$bt[4]["line"].")<br>" : null).
-					($bt[5] ? "Backtrace file #3: ".$bt[5]["file"]." (line ".$bt[5]["line"].")<br>" : null).
-				"</div>";
-		}
-        
-        function safestring($string)
-        {           
-            return mysql_real_escape_string($string, $this->connectionid);
-        }
-        
+		$this->dbsource ("mysql");
+		$this->host = $host;
+		$this->uid = $uid;
+		$this->pwd = $pwd;
+		$this->database	= $database;
+		$this->avoidpersistence = $avoidpersistence;
 	}
 
-?>
+	function connect($select = true)
+	{
+		$this->connectionid = mysql_connect ($this->host, $this->uid, $this->pwd, $this->avoidpersistence);
+		if($select)
+			$this->select($this->database);
+		return $this->connectionid;
+	}
+
+	function select($database)
+	{
+		mysql_select_db($database);
+	}
+
+	function disconnect ()
+	{
+		mysql_close ($this->connectionid);
+	}
+
+	function query ($sql)
+	{
+        $this->last_query = $sql;
+        		
+		$this->result = mysql_query ($sql, $this->connectionid);
+		
+		return $this->result;
+	}
+
+	function free ()
+	{
+		mysql_free_result ($this->result);
+	}
+
+	function isanyresult ()
+	{
+		return mysql_affected_rows ($this->connectionid);
+	}
+
+	function fetchrow ()
+	{
+		$this->row = mysql_fetch_assoc ($this->result);
+		return $this->row;
+	}
+
+	function getfield ($field)
+	{
+		return $this->row[$field];
+	}
+
+	function countrows ()
+	{
+		return mysql_num_rows ($this->result);
+	}
+	
+	function seek_row($numrow)
+	{
+        return mysql_data_seek($this->result, $numrow);
+	}
+
+	function getinsertid ()
+	{
+		return mysql_insert_id ($this->connectionid);
+	}
+	
+	function get_errno()
+	{
+	  return mysql_errno($this->connectionid);
+	}
+	
+	function get_err()
+	{
+	  return mysql_error($this->connectionid);
+	}
+	
+	function dump_error()
+	{
+		$bt = debug_backtrace();
+        return
+			"<div style=\"margin: 5px; padding: 5px; background: #fe0; color: #444;\">".
+				"MySQL Error: (".$this->get_errno().")".$this->get_err()."<br>".
+				"Query: \"".$this->last_query."\"<br>".
+				($bt[1] ? "Backtrace file #1: ".$bt[1]["file"]." (line ".$bt[1]["line"].")<br>" : null).
+				($bt[2] ? "Backtrace file #2: ".$bt[2]["file"]." (line ".$bt[2]["line"].")<br>" : null).
+				($bt[3] ? "Backtrace file #3: ".$bt[3]["file"]." (line ".$bt[3]["line"].")<br>" : null).
+				($bt[4] ? "Backtrace file #3: ".$bt[4]["file"]." (line ".$bt[4]["line"].")<br>" : null).
+				($bt[5] ? "Backtrace file #3: ".$bt[5]["file"]." (line ".$bt[5]["line"].")<br>" : null).
+			"</div>";
+	}
+    
+    function safestring($string)
+    {           
+        return mysql_real_escape_string($string, $this->connectionid);
+    }
+    
+}

--- a/lib/database/dbsource_mysql_pdo.inc.php
+++ b/lib/database/dbsource_mysql_pdo.inc.php
@@ -1,146 +1,144 @@
-<?
+<?php
 
-	class dbsource_mysql_pdo extends dbsource
+class dbsource_mysql_pdo extends dbsource
+{
+	var $host;
+	var $uid;
+	var $pwd;
+	var $database;
+	var $charset;
+	var $is_persistent;
+	var $is_emulate_prepares;
+	var $errmode;
+	var $pdo;
+	var $stmt;
+
+	function dbsource_mysql_pdo ($host, $uid, $pwd, $database = "", $charset = "utf8", $is_persistent = true, $is_emulate_prepares = false, $errmode = PDO::ERRMODE_EXCEPTION)
 	{
-		var $host;
-		var $uid;
-		var $pwd;
-		var $database;
-		var $charset;
-		var $is_persistent;
-		var $is_emulate_prepares;
-		var $errmode;
-		var $pdo;
-		var $stmt;
-
-		function dbsource_mysql_pdo ($host, $uid, $pwd, $database = "", $charset = "utf8", $is_persistent = true, $is_emulate_prepares = false, $errmode = PDO::ERRMODE_EXCEPTION)
-		{
-			$this->dbsource ("mysql_pdo");
-			$this->host = $host;
-			$this->uid = $uid;
-			$this->pwd = $pwd;
-			$this->database = $database;
-			$this->charset = $charset;
-			$this->is_persistent = $is_persistent;
-			$this->is_emulate_prepares = $is_emulate_prepares;
-			$this->errmode = $errmode;
-		}
-
-		function connect($select = true)
-		{
-			$this->pdo = new PDO(
-				"mysql:".
-				"host=".$this->host.
-				($select && $this->database ? ";dbname=".$this->database : "").
-				($this->charset ? ";charset=".$this->charset : ""),
-				$this->uid,
-				$this->pwd,
-				array(
-					PDO::ATTR_PERSISTENT => $this->is_persistent,
-					PDO::ATTR_EMULATE_PREPARES => $this->is_emulate_prepares,
-					PDO::ATTR_ERRMODE => $this->errmode
-				)
-			);
-
-			if($this->pdo)
-				return true;
-			else
-				return false;
-		}
-
-		function select($database)
-		{
-			$this->pdo->query("use ".$database);
-		}
-
-		function disconnect ()
-		{
-			echo "!"; die;
-			$this->pdo = null;
-		}
-
-		function query($query)
-		{
-            if(!parent::query($query))
-				return false;
-
-			try
-			{
-				$this->stmt = $this->pdo->query($query);
-			}
-			catch(PDOException $ex)
-			{
-				$this->dump_error($ex);
-				return false;
-			}
-
-			return true;
-		}
-
-		function run_free()
-		{
-			$this->stmt = null;
-		}
-
-		function run_isanyresult()
-		{			
-			if($this->stmt->rowCount() < 1)
-				return false;
-			else
-				return true;
-		}
-
-		function run_fetchrow()
-		{
-			$this->row = $this->stmt->fetch(PDO::FETCH_ASSOC);
-			return $this->row;
-		}
-
-		function getfield($field)
-		{
-			return $this->row[$field];
-		}
-
-		function run_countrows()
-		{
-			return $this->stmt->rowCount();
-		}
-		
-		function run_seek_row($numrow)
-		{
-			return $this->stmt->fetch(PDO::FETCH_ASSOC, PDO::FETCH_ORI_ABS, $numrow);
-		}
-
-		function getinsertid ()
-		{
-			return $this->pdo->lastInsertId();
-		}
-		
-		function get_error($ex)
-		{
-			if(!$this->is_debug)
-				return false;
-
-            return
-				"MySQL PDO Error: (".$ex->getMessage().")<br><br>".
-				"Query: \"".$this->last_query."\"";
-		}
-
-		function dump_error($ex)
-		{
-			echo $this->get_error($ex);
-		}
-		
-		function safestring($string)
-        {
-			$string = $this->pdo->quote($string);
-
-			if(substr($string, 0, 1) == "'" && substr($string, -1, 1) == "'")
-				return substr($string, 1, -1);
-			else
-				return $string;
-        }
-        
+		$this->dbsource ("mysql_pdo");
+		$this->host = $host;
+		$this->uid = $uid;
+		$this->pwd = $pwd;
+		$this->database = $database;
+		$this->charset = $charset;
+		$this->is_persistent = $is_persistent;
+		$this->is_emulate_prepares = $is_emulate_prepares;
+		$this->errmode = $errmode;
 	}
 
-?>
+	function connect($select = true)
+	{
+		$this->pdo = new PDO(
+			"mysql:".
+			"host=".$this->host.
+			($select && $this->database ? ";dbname=".$this->database : "").
+			($this->charset ? ";charset=".$this->charset : ""),
+			$this->uid,
+			$this->pwd,
+			array(
+				PDO::ATTR_PERSISTENT => $this->is_persistent,
+				PDO::ATTR_EMULATE_PREPARES => $this->is_emulate_prepares,
+				PDO::ATTR_ERRMODE => $this->errmode
+			)
+		);
+
+		if($this->pdo)
+			return true;
+		else
+			return false;
+	}
+
+	function select($database)
+	{
+		$this->pdo->query("use ".$database);
+	}
+
+	function disconnect ()
+	{
+		echo "!"; die;
+		$this->pdo = null;
+	}
+
+	function query($query)
+	{
+        if(!parent::query($query))
+			return false;
+
+		try
+		{
+			$this->stmt = $this->pdo->query($query);
+		}
+		catch(PDOException $ex)
+		{
+			$this->dump_error($ex);
+			return false;
+		}
+
+		return true;
+	}
+
+	function run_free()
+	{
+		$this->stmt = null;
+	}
+
+	function run_isanyresult()
+	{			
+		if($this->stmt->rowCount() < 1)
+			return false;
+		else
+			return true;
+	}
+
+	function run_fetchrow()
+	{
+		$this->row = $this->stmt->fetch(PDO::FETCH_ASSOC);
+		return $this->row;
+	}
+
+	function getfield($field)
+	{
+		return $this->row[$field];
+	}
+
+	function run_countrows()
+	{
+		return $this->stmt->rowCount();
+	}
+	
+	function run_seek_row($numrow)
+	{
+		return $this->stmt->fetch(PDO::FETCH_ASSOC, PDO::FETCH_ORI_ABS, $numrow);
+	}
+
+	function getinsertid ()
+	{
+		return $this->pdo->lastInsertId();
+	}
+	
+	function get_error($ex)
+	{
+		if(!$this->is_debug)
+			return false;
+
+        return
+			"MySQL PDO Error: (".$ex->getMessage().")<br><br>".
+			"Query: \"".$this->last_query."\"";
+	}
+
+	function dump_error($ex)
+	{
+		echo $this->get_error($ex);
+	}
+	
+	function safestring($string)
+    {
+		$string = $this->pdo->quote($string);
+
+		if(substr($string, 0, 1) == "'" && substr($string, -1, 1) == "'")
+			return substr($string, 1, -1);
+		else
+			return $string;
+    }
+    
+}

--- a/lib/database/dbsource_mysqli.inc.php
+++ b/lib/database/dbsource_mysqli.inc.php
@@ -1,120 +1,118 @@
-<?
+<?php
 
-	class dbsource_mysqli extends dbsource
+class dbsource_mysqli extends dbsource
+{
+	var $host;
+	var $uid;
+	var $pwd;
+	var $database;
+	var $connectionid;
+
+	function dbsource_mysqli ($host, $uid, $pwd, $database = "")
 	{
-		var $host;
-		var $uid;
-		var $pwd;
-		var $database;
-		var $connectionid;
-
-		function dbsource_mysqli ($host, $uid, $pwd, $database = "")
-		{
-			$this->dbsource ("mysqli");
-			$this->host		= $host;
-			$this->uid		= $uid;
-			$this->pwd		= $pwd;
-			$this->database	= $database;
-		}
-
-		function connect($select = true)
-		{
-			$this->connectionid = mysqli_connect ($this->host, $this->uid, $this->pwd);
-			if($select)
-				$this->select($this->database);
-			return $this->connectionid;
-		}
-
-		function select($database)
-		{
-			mysqli_select_db($this->connectionid, $database);
-		}
-
-		function disconnect ()
-		{
-			mysqli_close ($this->connectionid);
-		}
-
-		function query($query)
-		{
-            if(!parent::query($query))
-				return false;
-            		
-			if(!$this->result = mysqli_query($this->connectionid, $query))
-                echo $this->dump_error();
-			
-			return $this->result;
-		}
-
-		function run_free()
-		{
-			mysqli_free_result ($this->result);
-		}
-
-		function run_isanyresult()
-		{			
-			return mysqli_affected_rows($this->connectionid);
-		}
-
-		function run_fetchrow()
-		{
-			$this->row = mysqli_fetch_assoc ($this->result);
-			return $this->row;
-		}
-
-		function getfield($field)
-		{
-			return $this->row[$field];
-		}
-
-		function run_countrows()
-		{
-			return mysqli_num_rows ($this->result);
-		}
-		
-		function run_seek_row($numrow)
-		{
-            return mysqli_data_seek($this->result, $numrow);
-		}
-
-		function getinsertid ()
-		{
-			return mysqli_insert_id ($this->connectionid);
-		}
-		
-		function get_errno()
-		{
-		  return mysqli_errno($this->connectionid);
-		}
-		
-		function get_err()
-		{
-		  return mysqli_error($this->connectionid);
-		}
-		
-		function dump_error()
-		{
-			if(!$this->is_debug)
-				return false;
-
-			$bt = debug_backtrace();
-            return
-				"<div style=\"margin: 5px; padding: 5px; background: #fe0; color: #444;\">".
-					"MySQL Error: (".$this->get_errno().")".$this->get_err()."<br>".
-					"Query: \"".$this->last_query."\"<br>".
-					($bt[1] ? "Backtrace file #1: ".$bt[1]["file"]." (line ".$bt[1]["line"].")<br>" : null).
-					($bt[2] ? "Backtrace file #2: ".$bt[2]["file"]." (line ".$bt[2]["line"].")<br>" : null).
-					($bt[3] ? "Backtrace file #3: ".$bt[3]["file"]." (line ".$bt[3]["line"].")<br>" : null).
-					($bt[4] ? "Backtrace file #3: ".$bt[4]["file"]." (line ".$bt[4]["line"].")<br>" : null).
-					($bt[5] ? "Backtrace file #3: ".$bt[5]["file"]." (line ".$bt[5]["line"].")<br>" : null).
-				"</div>";
-		}
-		
-		function safestring($string)
-        {
-            return mysqli_real_escape_string($this->connectionid, $string);
-        }
-        
+		$this->dbsource ("mysqli");
+		$this->host		= $host;
+		$this->uid		= $uid;
+		$this->pwd		= $pwd;
+		$this->database	= $database;
 	}
 
-?>
+	function connect($select = true)
+	{
+		$this->connectionid = mysqli_connect ($this->host, $this->uid, $this->pwd);
+		if($select)
+			$this->select($this->database);
+		return $this->connectionid;
+	}
+
+	function select($database)
+	{
+		mysqli_select_db($this->connectionid, $database);
+	}
+
+	function disconnect ()
+	{
+		mysqli_close ($this->connectionid);
+	}
+
+	function query($query)
+	{
+        if(!parent::query($query))
+			return false;
+        		
+		if(!$this->result = mysqli_query($this->connectionid, $query))
+            echo $this->dump_error();
+		
+		return $this->result;
+	}
+
+	function run_free()
+	{
+		mysqli_free_result ($this->result);
+	}
+
+	function run_isanyresult()
+	{			
+		return mysqli_affected_rows($this->connectionid);
+	}
+
+	function run_fetchrow()
+	{
+		$this->row = mysqli_fetch_assoc ($this->result);
+		return $this->row;
+	}
+
+	function getfield($field)
+	{
+		return $this->row[$field];
+	}
+
+	function run_countrows()
+	{
+		return mysqli_num_rows ($this->result);
+	}
+	
+	function run_seek_row($numrow)
+	{
+        return mysqli_data_seek($this->result, $numrow);
+	}
+
+	function getinsertid ()
+	{
+		return mysqli_insert_id ($this->connectionid);
+	}
+	
+	function get_errno()
+	{
+	  return mysqli_errno($this->connectionid);
+	}
+	
+	function get_err()
+	{
+	  return mysqli_error($this->connectionid);
+	}
+	
+	function dump_error()
+	{
+		if(!$this->is_debug)
+			return false;
+
+		$bt = debug_backtrace();
+        return
+			"<div style=\"margin: 5px; padding: 5px; background: #fe0; color: #444;\">".
+				"MySQL Error: (".$this->get_errno().")".$this->get_err()."<br>".
+				"Query: \"".$this->last_query."\"<br>".
+				($bt[1] ? "Backtrace file #1: ".$bt[1]["file"]." (line ".$bt[1]["line"].")<br>" : null).
+				($bt[2] ? "Backtrace file #2: ".$bt[2]["file"]." (line ".$bt[2]["line"].")<br>" : null).
+				($bt[3] ? "Backtrace file #3: ".$bt[3]["file"]." (line ".$bt[3]["line"].")<br>" : null).
+				($bt[4] ? "Backtrace file #3: ".$bt[4]["file"]." (line ".$bt[4]["line"].")<br>" : null).
+				($bt[5] ? "Backtrace file #3: ".$bt[5]["file"]." (line ".$bt[5]["line"].")<br>" : null).
+			"</div>";
+	}
+	
+	function safestring($string)
+    {
+        return mysqli_real_escape_string($this->connectionid, $string);
+    }
+    
+}

--- a/lib/database/dbsource_oracle.inc.php
+++ b/lib/database/dbsource_oracle.inc.php
@@ -1,69 +1,67 @@
-<?
-	
-	class dbsource_oracle extends dbsource
-	{
-		var $uid;
-		var $pwd;
-		var $schema;
-		
-		var $statement;
-		var $row;
-		var $errors;
-		
-		function dbsource_oracle ($uid, $pwd, $schema)
-		{
-			$this->dbsource ("oracle");
-			$this->uid		= $uid;
-			$this->pwd		= $pwd;
-			$this->schema	= $schema;
-		}
-		
-		function connect ()
-		{
-			$this->connectionid = OCILogon($this->uid, $this->pwd, $this->schema);
-			return $this->connectionid;
-		}
-		
-		function disconnect ()
-		{
-			return OCILogOff ($this->connectionid);
-		}
-		
-		function query ($sql)
-		{
-			$this->statement = @OCIParse ($this->connectionid, $sql);
-			@OCIExecute ($this->statement, OCI_DEFAULT);
-			$this->errors = OCIError($this->statement);
-		}
-		
-		function checkerrors ()
-		{
-			if ($this->errors["code"])
-				return "[Código ".$this->errors["code"]."] ".$this->errors["message"];
-			return false;
-		}
-		
-		function fetchrow ()
-		{
-			OCIFetchInto($this->statement, &$results, OCI_ASSOC+OCI_RETURN_NULLS);
-			$this->row = $results;
-			return $results;
-		}
-		
-		function getfield ($field)
-		{
-			return $this->row[$field];
-		}
-		
-		function countrows ()
-		{
-			return OCIRowCount ($this->statement);
-		}
-		
-		function getfield_date ($string)
-		{
-			return strtotime ($this->row[$string]);
-		}
-	}
+<?php
 
-?>
+class dbsource_oracle extends dbsource
+{
+	var $uid;
+	var $pwd;
+	var $schema;
+	
+	var $statement;
+	var $row;
+	var $errors;
+	
+	function dbsource_oracle ($uid, $pwd, $schema)
+	{
+		$this->dbsource ("oracle");
+		$this->uid		= $uid;
+		$this->pwd		= $pwd;
+		$this->schema	= $schema;
+	}
+	
+	function connect ()
+	{
+		$this->connectionid = OCILogon($this->uid, $this->pwd, $this->schema);
+		return $this->connectionid;
+	}
+	
+	function disconnect ()
+	{
+		return OCILogOff ($this->connectionid);
+	}
+	
+	function query ($sql)
+	{
+		$this->statement = @OCIParse ($this->connectionid, $sql);
+		@OCIExecute ($this->statement, OCI_DEFAULT);
+		$this->errors = OCIError($this->statement);
+	}
+	
+	function checkerrors ()
+	{
+		if ($this->errors["code"])
+			return "[Código ".$this->errors["code"]."] ".$this->errors["message"];
+		return false;
+	}
+	
+	function fetchrow ()
+	{
+		OCIFetchInto($this->statement, &$results, OCI_ASSOC+OCI_RETURN_NULLS);
+		$this->row = $results;
+		return $results;
+	}
+	
+	function getfield ($field)
+	{
+		return $this->row[$field];
+	}
+	
+	function countrows ()
+	{
+		return OCIRowCount ($this->statement);
+	}
+	
+	function getfield_date ($string)
+	{
+		return strtotime ($this->row[$string]);
+	}
+}

--- a/scripts/delivery.php
+++ b/scripts/delivery.php
@@ -1,389 +1,387 @@
-<?
+<?php
 
-	/*
-		EMailqueue
-		Delivery component
-	*/
+/*
+	EMailqueue
+	Delivery component
+*/
+
+define("LIB_DIR", "lib");
+define("APP_DIR", "../");
+
+include APP_DIR."common.inc.php";
+
+include APP_DIR."lib/phpmailer/class.phpmailer.php";
+if (SEND_METHOD == "smtp")
+	include APP_DIR."lib/phpmailer/class.smtp.php";
+
+header("content-type: text/plain");
+set_time_limit(0);
+
+echo "Emailqueue · Delivery\n";
+if (IS_DEVEL_ENVIRONMENT) {
+    echo "Reminder: Running in development environment, ";
+    if (!$devel_emails)
+        echo "no emails will be sent.\n";
+    else
+        echo "only emails to ".implode(", ", $devel_emails)." will be sent.\n";
+}
+echo "Maximum delivery timeout: ".(MAXIMUM_DELIVERY_TIMEOUT ? $utils->secondstohumantime(MAXIMUM_DELIVERY_TIMEOUT) : "unlimited")."\n";
+echo "Delivery interval: ".(DELIVERY_INTERVAL ? number_format((DELIVERY_INTERVAL/100), 2, ",", "")." seconds" : "none")."\n";
+echo "Maximum emails to deliver: ".(MAX_DELIVERS_A_TIME ? MAX_DELIVERS_A_TIME : "no limit")."\n";
+echo "Process started on: ".date("j/n/Y H:i.s")."\n";
+
+// Get blacklisted emails
+$db->query("select * from blacklist");
+if ($db->isanyresult()) {
+    while($row = $db->fetchrow())
+        $blacklisted_emails[] = $row["email"];
+    $db->free();
+}
+
+// Query emails to be sent
+$db->query("
+	select			*
+	from			emails
+	where			is_sent = 0
+	and				is_cancelled = 0
+	and				is_blocked = 0
+	and
+	(
+		date_queued is null
+		or
+		(date_queued is not null and date_queued <= '".date("Y-n-j H:i:s", $now)."')
+	)
+	order by		is_inmediate desc, priority asc, date_queued asc
+	".(MAX_DELIVERS_A_TIME ? " LIMIT 0, ".MAX_DELIVERS_A_TIME : "")."
+");
+
+if (!$db->isanyresult()) {
+	echo "No emails on queue.\n";
+}
+else {
+	while ($row = $db->fetchrow())
+		$emails[] = $row;
 	
-	define("LIB_DIR", "lib");
-	define("APP_DIR", "../");
-	
-	include APP_DIR."common.inc.php";
-	
-	include APP_DIR."lib/phpmailer/class.phpmailer.php";
-	if (SEND_METHOD == "smtp")
-		include APP_DIR."lib/phpmailer/class.smtp.php";
-	
-	header("content-type: text/plain");
-	set_time_limit(0);
-	
-	echo "Emailqueue · Delivery\n";
-    if (IS_DEVEL_ENVIRONMENT) {
-        echo "Reminder: Running in development environment, ";
-        if (!$devel_emails)
-            echo "no emails will be sent.\n";
-        else
-            echo "only emails to ".implode(", ", $devel_emails)." will be sent.\n";
-    }
-	echo "Maximum delivery timeout: ".(MAXIMUM_DELIVERY_TIMEOUT ? $utils->secondstohumantime(MAXIMUM_DELIVERY_TIMEOUT) : "unlimited")."\n";
-	echo "Delivery interval: ".(DELIVERY_INTERVAL ? number_format((DELIVERY_INTERVAL/100), 2, ",", "")." seconds" : "none")."\n";
-	echo "Maximum emails to deliver: ".(MAX_DELIVERS_A_TIME ? MAX_DELIVERS_A_TIME : "no limit")."\n";
-	echo "Process started on: ".date("j/n/Y H:i.s")."\n";
+	$timecontrol_start = mktime();
 
-    // Get blacklisted emails
-    $db->query("select * from blacklist");
-    if ($db->isanyresult()) {
-        while($row = $db->fetchrow())
-            $blacklisted_emails[] = $row["email"];
-        $db->free();
-    }
+	$mail = new PHPMailer(true);
 
-    // Query emails to be sent
-	$db->query("
-		select			*
-		from			emails
-		where			is_sent = 0
-		and				is_cancelled = 0
-		and				is_blocked = 0
-		and
-		(
-			date_queued is null
-			or
-			(date_queued is not null and date_queued <= '".date("Y-n-j H:i:s", $now)."')
-		)
-		order by		is_inmediate desc, priority asc, date_queued asc
-		".(MAX_DELIVERS_A_TIME ? " LIMIT 0, ".MAX_DELIVERS_A_TIME : "")."
-	");
-	
-	if (!$db->isanyresult()) {
-		echo "No emails on queue.\n";
-	}
-	else {
-		while ($row = $db->fetchrow())
-			$emails[] = $row;
-		
-		$timecontrol_start = mktime();
+	$mail->CharSet = CHARSET;
 
-		$mail = new PHPMailer(true);
+    if (SEND_METHOD == "smtp") {
+        $mail->IsSMTP();
+        $mail->Host = SMTP_SERVER;
+        $mail->SMTPKeepAlive = true;
 
-		$mail->CharSet = CHARSET;
-
-        if (SEND_METHOD == "smtp") {
-            $mail->IsSMTP();
-            $mail->Host = SMTP_SERVER;
-            $mail->SMTPKeepAlive = true;
-
-            if (SMTP_IS_AUTHENTICATION) {
-                $mail->SMTPAuth = true;
-                $mail->Port = SMTP_PORT;
-                $mail->Username = SMTP_AUTHENTICATION_USERNAME;
-                $mail->Password = SMTP_AUTHENTICATION_PASSWORD;
-            }
+        if (SMTP_IS_AUTHENTICATION) {
+            $mail->SMTPAuth = true;
+            $mail->Port = SMTP_PORT;
+            $mail->Username = SMTP_AUTHENTICATION_USERNAME;
+            $mail->Password = SMTP_AUTHENTICATION_PASSWORD;
         }
-        else if (SEND_METHOD == "sendmail")
-        	$mail->IsSendmail();
+    }
+    else if (SEND_METHOD == "sendmail")
+    	$mail->IsSendmail();
+	
+	foreach ($emails as $email) {
+
+		$mail->clearAllRecipients();
+		$mail->clearAddresses();
+		$mail->clearCCs();
+		$mail->clearBCCs();
+		$mail->clearReplyTos();
+		$mail->clearAttachments();
+		$mail->clearCustomHeaders();
+
+		flush();
+		echo $email["id"].": Sending email to ".$email["to"]." ... ";
 		
-		foreach ($emails as $email) {
-
-			$mail->clearAllRecipients();
-			$mail->clearAddresses();
-			$mail->clearCCs();
-			$mail->clearBCCs();
-			$mail->clearReplyTos();
-			$mail->clearAttachments();
-			$mail->clearCustomHeaders();
-
-			flush();
-			echo $email["id"].": Sending email to ".$email["to"]." ... ";
-			
-			setsendingnow($email["id"]);
-			
-			if ($email["is_sendingnow"]) {
-                echo "already being sent.";
-                add_incidence($email["id"], "Try to send an email that is already being sent");
-                $logger->add_log_incidence(
-					array
-					(
-						$email["id"],
-						$email["to"],
-						"Email skipped",
-						"Try to send an email that is already being sent"
-					)
-				);
-			}
-			
-			if (!checkemail($email["to"])) {
-				echo "bad recipient email address.";
-				add_incidence($email["id"], "Incorrect recipient email address: ".$email["to"]);
+		setsendingnow($email["id"]);
+		
+		if ($email["is_sendingnow"]) {
+            echo "already being sent.";
+            add_incidence($email["id"], "Try to send an email that is already being sent");
+            $logger->add_log_incidence(
+				array
+				(
+					$email["id"],
+					$email["to"],
+					"Email skipped",
+					"Try to send an email that is already being sent"
+				)
+			);
+		}
+		
+		if (!checkemail($email["to"])) {
+			echo "bad recipient email address.";
+			add_incidence($email["id"], "Incorrect recipient email address: ".$email["to"]);
+			cancel($email["id"]);
+			$logger->add_log_incidence(
+				array(
+					$email["id"],
+					$email["to"],
+					"Email cancelled",
+					"Incorrect recipient email address"
+				)
+			);
+		}
+		
+		if (!checkemail($email["from"])) {
+			echo "bad addressee email address.";
+			add_incidence($email["id"], "Incorrect addressee email address: ".$email["from"]);
+			cancel($email["id"]);
+			$logger->add_log_incidence
+			(
+				array
+				(
+					$email["id"],
+					$email["to"],
+					"Email cancelled",
+					"Incorrect addressee email address"
+				)
+			);
+		}
+		
+		// Check black list
+		if (isset($blacklisted_emails))
+            if (is_array($blacklisted_emails) and in_array(strtolower(trim($email["to"])), $blacklisted_emails)) {
+				echo "recipient is on the black list.";
+				add_incidence($email["id"], "Recipient is on the black list: ".$email["to"]);
 				cancel($email["id"]);
 				$logger->add_log_incidence(
 					array(
 						$email["id"],
 						$email["to"],
 						"Email cancelled",
-						"Incorrect recipient email address"
+						"Recipient is on the black list"
 					)
 				);
 			}
-			
-			if (!checkemail($email["from"])) {
-				echo "bad addressee email address.";
-				add_incidence($email["id"], "Incorrect addressee email address: ".$email["from"]);
-				cancel($email["id"]);
-				$logger->add_log_incidence
-				(
-					array
-					(
-						$email["id"],
-						$email["to"],
-						"Email cancelled",
-						"Incorrect addressee email address"
-					)
-				);
-			}
-			
-			// Check black list
-			if (isset($blacklisted_emails))
-	            if (is_array($blacklisted_emails) and in_array(strtolower(trim($email["to"])), $blacklisted_emails)) {
-					echo "recipient is on the black list.";
-					add_incidence($email["id"], "Recipient is on the black list: ".$email["to"]);
+
+        if (!IS_DEVEL_ENVIRONMENT || (IS_DEVEL_ENVIRONMENT && in_array($email["to"], $devel_emails))) {
+
+            $isError = false;
+            try {
+
+                    if ($email["custom_headers"]) {
+                        $custom_headers = unserialize($email["custom_headers"]);
+
+                        if (is_array($custom_headers)) {
+
+                            if (array_key_exists("Content-Transfer-Encoding", $custom_headers)) {
+                                $mail->Encoding = $custom_headers["Content-Transfer-Encoding"];
+                                // We don't want to iterate over this header again in the foreach cicle.
+                                unset($custom_headers["Content-Transfer-Encoding"]);
+                            } else {
+                                $mail->Encoding = CONTENT_TRANSFER_ENCODING;
+                            }
+
+                            foreach ($custom_headers as $header => $value) {
+                                $mail->AddCustomHeader($header, $value);
+                            }
+                        }
+                    } else {
+                        $mail->Encoding = CONTENT_TRANSFER_ENCODING;
+                    }
+
+                if ($email["replyto"] != "") {
+                    if($email["replyto_name"] != "")
+                        $mail->AddReplyTo($email["replyto"], $email["replyto_name"]);
+                    else
+                        $mail->AddReplyTo($email["replyto"]);
+                }
+                else {
+                    $mail->AddReplyTo($email["from"]);
+                }
+
+                $mail->From = $email["from"];
+                if($email["from_name"] != "")
+                    $mail->FromName = $email["from_name"];
+
+                $to = $email["to"];
+
+                $mail->AddAddress($to);
+
+                $mail->Subject = $email["subject"];
+
+                $mail->WordWrap = 80;
+
+                $body = $email["content"];
+                $body = preg_replace('/\\\\/','', $body);
+
+                if($email["is_html"]) {
+                    $mail->IsHTML(true);
+                        $mail->AltBody = "Please use an HTML compatible email viewer!";
+                        $mail->MsgHTML($body);
+                    } else {
+                        $mail->Body = $body;
+                    }
+
+                if($email["is_embed_images"])
+                	embed_images($body, $mail);
+
+
+                if($email["content_nonhtml"] != "")
+                    $mail->AltBody = $email["content_nonhtml"];
+
+                if($email["list_unsubscribe_url"] != "")
+                    $mail->AddCustomHeader("List-Unsubscribe: <".$email["list_unsubscribe_url"].">");
+
+                // Add attachments
+                if($email["attachments"]) {
+                	$attachments = unserialize($email["attachments"]);
+                	if (is_array($attachments)) {
+                    	foreach ($attachments as $attachment) {
+
+                    		if (!is_array($attachment))
+                    			continue;
+
+                    		if (!isset($attachment["fileName"]))
+		                        $attachment["fileName"] = basename($attachment["path"]);
+
+		                    if (!isset($attachment["encoding"]))
+		                        $attachment["encoding"] = "base64";
+
+		                    if (!isset($attachment["type"])) {
+		                        if ($finfo = finfo_open(FILEINFO_MIME_TYPE)) {
+		                            if (!$mimeType = finfo_file($finfo, $attachment["path"]))
+		                            	throw new Exception("Can't guess mimetype for ".$attachment["path"]);
+		                            finfo_close($finfo);
+		                            $attachment["type"] = $mimeType;
+		                        }
+		                    }
+
+                    		$mail->AddAttachment(
+                    			$attachment["path"],
+                    			$attachment["fileName"],
+                    			$attachment["encoding"],
+                    			$attachment["type"]
+                    		);
+                    	}
+                    }
+                }
+            
+            	$mail->Send();
+
+            } catch (phpmailerException $e) {
+
+            	$isError = true;
+            	$errorText = $e->getMessage();
+
+            } catch (Exception $e) {
+
+            	$isError = true;
+            	$errorText = $e->getMessage();
+
+            }
+
+            if ($isError) {
+
+            	echo "Error while sending email: ".$errorText.", ";
+				
+				if ($email["error_count"] == SENDING_RETRY_MAX_ATTEMPTS-1) {
+					update_error_count($email["id"], $email["error_count"]+1);
+					$incidence_text = "Error while sending email: [".$errorText."] Cancelled: No more sending attempts allowed";
+					add_incidence($email["id"], $incidence_text);
 					cancel($email["id"]);
 					$logger->add_log_incidence(
 						array(
 							$email["id"],
 							$email["to"],
 							"Email cancelled",
-							"Recipient is on the black list"
+							"No more sending attempts allowed"
 						)
 					);
+					echo "No more attempts allowed, cancelled";
 				}
-
-            if (!IS_DEVEL_ENVIRONMENT || (IS_DEVEL_ENVIRONMENT && in_array($email["to"], $devel_emails))) {
-
-                $isError = false;
-                try {
-
-                        if ($email["custom_headers"]) {
-                            $custom_headers = unserialize($email["custom_headers"]);
-
-                            if (is_array($custom_headers)) {
-
-                                if (array_key_exists("Content-Transfer-Encoding", $custom_headers)) {
-                                    $mail->Encoding = $custom_headers["Content-Transfer-Encoding"];
-                                    // We don't want to iterate over this header again in the foreach cicle.
-                                    unset($custom_headers["Content-Transfer-Encoding"]);
-                                } else {
-                                    $mail->Encoding = CONTENT_TRANSFER_ENCODING;
-                                }
-
-                                foreach ($custom_headers as $header => $value) {
-                                    $mail->AddCustomHeader($header, $value);
-                                }
-                            }
-                        } else {
-                            $mail->Encoding = CONTENT_TRANSFER_ENCODING;
-                        }
-
-	                if ($email["replyto"] != "") {
-	                    if($email["replyto_name"] != "")
-	                        $mail->AddReplyTo($email["replyto"], $email["replyto_name"]);
-	                    else
-	                        $mail->AddReplyTo($email["replyto"]);
-	                }
-	                else {
-	                    $mail->AddReplyTo($email["from"]);
-	                }
-
-	                $mail->From = $email["from"];
-	                if($email["from_name"] != "")
-	                    $mail->FromName = $email["from_name"];
-
-	                $to = $email["to"];
-
-	                $mail->AddAddress($to);
-
-	                $mail->Subject = $email["subject"];
-
-	                $mail->WordWrap = 80;
-
-	                $body = $email["content"];
-	                $body = preg_replace('/\\\\/','', $body);
-
-	                if($email["is_html"]) {
-	                    $mail->IsHTML(true);
-                            $mail->AltBody = "Please use an HTML compatible email viewer!";
-                            $mail->MsgHTML($body);
-                        } else {
-                            $mail->Body = $body;
-                        }
-
-	                if($email["is_embed_images"])
-	                	embed_images($body, $mail);
-
-
-	                if($email["content_nonhtml"] != "")
-	                    $mail->AltBody = $email["content_nonhtml"];
-
-	                if($email["list_unsubscribe_url"] != "")
-	                    $mail->AddCustomHeader("List-Unsubscribe: <".$email["list_unsubscribe_url"].">");
-
-	                // Add attachments
-	                if($email["attachments"]) {
-	                	$attachments = unserialize($email["attachments"]);
-	                	if (is_array($attachments)) {
-	                    	foreach ($attachments as $attachment) {
-
-	                    		if (!is_array($attachment))
-	                    			continue;
-
-	                    		if (!isset($attachment["fileName"]))
-			                        $attachment["fileName"] = basename($attachment["path"]);
-
-			                    if (!isset($attachment["encoding"]))
-			                        $attachment["encoding"] = "base64";
-
-			                    if (!isset($attachment["type"])) {
-			                        if ($finfo = finfo_open(FILEINFO_MIME_TYPE)) {
-			                            if (!$mimeType = finfo_file($finfo, $attachment["path"]))
-			                            	throw new Exception("Can't guess mimetype for ".$attachment["path"]);
-			                            finfo_close($finfo);
-			                            $attachment["type"] = $mimeType;
-			                        }
-			                    }
-
-	                    		$mail->AddAttachment(
-	                    			$attachment["path"],
-	                    			$attachment["fileName"],
-	                    			$attachment["encoding"],
-	                    			$attachment["type"]
-	                    		);
-	                    	}
-	                    }
-	                }
-                
-                	$mail->Send();
-
-                } catch (phpmailerException $e) {
-
-                	$isError = true;
-                	$errorText = $e->getMessage();
-
-                } catch (Exception $e) {
-
-                	$isError = true;
-                	$errorText = $e->getMessage();
-
-                }
-
-                if ($isError) {
-
-                	echo "Error while sending email: ".$errorText.", ";
-					
-					if ($email["error_count"] == SENDING_RETRY_MAX_ATTEMPTS-1) {
-						update_error_count($email["id"], $email["error_count"]+1);
-						$incidence_text = "Error while sending email: [".$errorText."] Cancelled: No more sending attempts allowed";
-						add_incidence($email["id"], $incidence_text);
-						cancel($email["id"]);
-						$logger->add_log_incidence(
-							array(
-								$email["id"],
-								$email["to"],
-								"Email cancelled",
-								"No more sending attempts allowed"
-							)
-						);
-						echo "No more attempts allowed, cancelled";
-					}
-					else {
-						update_error_count($email["id"], $email["error_count"]+1);
-						$incidence_text = "Error while sending email: [".$errorText."] Scheduled for one more try";
-						add_incidence($email["id"], $incidence_text);
-						$logger->add_log_incidence(array(
-							$email["id"],
-							$email["to"],
-							"Email rescheduled",
-							$incidence_text
-						));
-						echo "Scheduled for one more try";
-					}
-
-                } else {
-					
-					mark_as_sent($email["id"]);
-					update_send_count($email["id"], $email["send_count"]+1);
-					update_sentdate($email["id"], $now);
-					$logger->add_log_delivery(array(
+				else {
+					update_error_count($email["id"], $email["error_count"]+1);
+					$incidence_text = "Error while sending email: [".$errorText."] Scheduled for one more try";
+					add_incidence($email["id"], $incidence_text);
+					$logger->add_log_incidence(array(
 						$email["id"],
-						"Email delivered",
-						$email["from"],
 						$email["to"],
-						$email["subject"]
+						"Email rescheduled",
+						$incidence_text
 					));
-					echo "Email processed";
-					
-					// Sleeping
-					usleep((DELIVERY_INTERVAL/100));
-
+					echo "Scheduled for one more try";
 				}
 
-            } else
-                echo "Running in devel environment, the recipient email isn't on the allowed devel emails. ";
-			
-			echo "\n";
-			
-			unsetsendingnow($email["id"]);
-			
-			// Check if maximum delivery timeout have been reached
-			if ((mktime() - $timecontrol_start) > MAXIMUM_DELIVERY_TIMEOUT) {
-                echo "Delivery proccess automatically stopped before it finished because of too many time spent on delivering. Time spent: ".(mktime() - $timecontrol_start)." seconds. Maximum time allowed: ".MAXIMUM_DELIVERY_TIMEOUT." seconds\n"; 
-                $logger->add_log_incidence(
-                    array(
-                        0,
-                        "",
-                        "Maximum delivery timeout reached",
-                        "The delivery proccess have been automatically stopped before it finishes because of too many time spent on delivering. Time spent: ".(mktime() - $timecontrol_start)." seconds. Maximum time allowed: ".MAXIMUM_DELIVERY_TIMEOUT." seconds" 
-                    )
-                );
-                break;
+            } else {
+				
+				mark_as_sent($email["id"]);
+				update_send_count($email["id"], $email["send_count"]+1);
+				update_sentdate($email["id"], $now);
+				$logger->add_log_delivery(array(
+					$email["id"],
+					"Email delivered",
+					$email["from"],
+					$email["to"],
+					$email["subject"]
+				));
+				echo "Email processed";
+				
+				// Sleeping
+				usleep((DELIVERY_INTERVAL/100));
+
 			}
+
+        } else
+            echo "Running in devel environment, the recipient email isn't on the allowed devel emails. ";
+		
+		echo "\n";
+		
+		unsetsendingnow($email["id"]);
+		
+		// Check if maximum delivery timeout have been reached
+		if ((mktime() - $timecontrol_start) > MAXIMUM_DELIVERY_TIMEOUT) {
+            echo "Delivery proccess automatically stopped before it finished because of too many time spent on delivering. Time spent: ".(mktime() - $timecontrol_start)." seconds. Maximum time allowed: ".MAXIMUM_DELIVERY_TIMEOUT." seconds\n"; 
+            $logger->add_log_incidence(
+                array(
+                    0,
+                    "",
+                    "Maximum delivery timeout reached",
+                    "The delivery proccess have been automatically stopped before it finishes because of too many time spent on delivering. Time spent: ".(mktime() - $timecontrol_start)." seconds. Maximum time allowed: ".MAXIMUM_DELIVERY_TIMEOUT." seconds" 
+                )
+            );
+            break;
 		}
-
-		$mail->SmtpClose();
-	}
-	
-	echo "Process ended on: ".date("j/n/Y H:i.s")."\n";
-	
-	$db->disconnect();
-
-	// Function embed_images below by Emmanuel Alves http://stackoverflow.com/users/3821744/emmanuel-alves
-	function embed_images(&$body, $mailer) {
-	    // get all img tags
-	    preg_match_all('/<img[^>]*src="([^"]*)"/i', $body, $matches);
-
-	    if (!isset($matches[0]))
-	        return;
-
-	    foreach ($matches[0] as $index => $img) {
-	        $src = $matches[1][$index];
-
-	        if (preg_match("/\.jpg/", $src)) {
-	            $dataType = "image/jpg";
-	        } elseif (preg_match("/\.png/", $src)) {
-	            $dataType = "image/jpg";
-	        } elseif (preg_match("/\.gif/", $src)) {
-	            $dataType = "image/gif";
-	        } else {
-	            // use the oldfashion way
-	            $id = 'img' . $index;            
-	            $mailer->AddEmbeddedImage($src, $id);
-	            $body = str_replace($src, 'cid:' . $id, $body);
-	        }
-
-	        if($dataType) { 
-	            $urlContent = file_get_contents($src);            
-	            $body = str_replace($src, 'data:'. $dataType .';base64,' . base64_encode($urlContent), $body);
-	        }
-	    }
 	}
 
-?>
+	$mail->SmtpClose();
+}
+
+echo "Process ended on: ".date("j/n/Y H:i.s")."\n";
+
+$db->disconnect();
+
+// Function embed_images below by Emmanuel Alves http://stackoverflow.com/users/3821744/emmanuel-alves
+function embed_images(&$body, $mailer) {
+    // get all img tags
+    preg_match_all('/<img[^>]*src="([^"]*)"/i', $body, $matches);
+
+    if (!isset($matches[0]))
+        return;
+
+    foreach ($matches[0] as $index => $img) {
+        $src = $matches[1][$index];
+
+        if (preg_match("/\.jpg/", $src)) {
+            $dataType = "image/jpg";
+        } elseif (preg_match("/\.png/", $src)) {
+            $dataType = "image/jpg";
+        } elseif (preg_match("/\.gif/", $src)) {
+            $dataType = "image/gif";
+        } else {
+            // use the oldfashion way
+            $id = 'img' . $index;            
+            $mailer->AddEmbeddedImage($src, $id);
+            $body = str_replace($src, 'cid:' . $id, $body);
+        }
+
+        if($dataType) { 
+            $urlContent = file_get_contents($src);            
+            $body = str_replace($src, 'data:'. $dataType .';base64,' . base64_encode($urlContent), $body);
+        }
+    }
+}

--- a/scripts/emailqueue_inject.class.php
+++ b/scripts/emailqueue_inject.class.php
@@ -1,231 +1,229 @@
-<?
-	
-	class emailqueue_inject {
-        var $db_host;
-        var $db_user;
-        var $db_password;
-        var $db_name;
-        var $db;
-        var $avoidpersistence;
-        var $default_priority = 10;
-        
-        function emailqueue_inject($db_host, $db_user, $db_password, $db_name, $avoidpersistence = false, $emailqueue_timezone = false) {
-            $this->db_host = $db_host;
-            $this->db_user = $db_user;
-            $this->db_password = $db_password;
-            $this->db_name = $db_name;
-            $this->avoidpersistence = $avoidpersistence;
-            if(!$emailqueue_timezone)
-                $this->emailqueue_timezone = DEFAULT_TIMEZONE;
-            else
-                $this->emailqueue_timezone = $emailqueue_timezone;
+<?php
+
+class emailqueue_inject {
+    var $db_host;
+    var $db_user;
+    var $db_password;
+    var $db_name;
+    var $db;
+    var $avoidpersistence;
+    var $default_priority = 10;
+    
+    function emailqueue_inject($db_host, $db_user, $db_password, $db_name, $avoidpersistence = false, $emailqueue_timezone = false) {
+        $this->db_host = $db_host;
+        $this->db_user = $db_user;
+        $this->db_password = $db_password;
+        $this->db_name = $db_name;
+        $this->avoidpersistence = $avoidpersistence;
+        if(!$emailqueue_timezone)
+            $this->emailqueue_timezone = DEFAULT_TIMEZONE;
+        else
+            $this->emailqueue_timezone = $emailqueue_timezone;
+    }
+    
+    function db_connect() {
+        if(!$this->connectionid = mysqli_connect($this->db_host, $this->db_user, $this->db_password)) {
+            echo "Emailqueue Inject class component: Cannot connect to database";
+            die;
         }
+		mysqli_select_db($this->connectionid, $this->db_name);
+		mysqli_query($this->connectionid, "set names utf8");
+    }
+    
+    function db_disconnect() {
+        mysqli_close($this->connectionid);
+    }
+    
+    function inject(
+        $foreign_id_a = null,
+        $foreign_id_b = null,
+        $priority = 10,
+        $is_inmediate = true,
+        $date_queued = null,
+        $is_html = false,
+        $from,
+        $from_name = "",
+        $to,
+        $replyto = "",
+        $replyto_name = "",
+        $subject,
+        $content,
+        $content_nonhtml = "",
+        $list_unsubscribe_url = "",
+        $attachments = false,
+        $is_embed_images = false,
+        $custom_headers = array()
+    ) {
+        $this->db_connect();
+    
+        $subject = str_replace("\\'", "'", $subject);
+        $subject = str_replace("'", "\'", $subject);
+
+        // Some recommendations have been found about not sending emails longer than 63k bytes, it seems that triggers lots of spam-detection alarms.
+        if(strlen($content) > 63000)
+            $content = substr($content, 0, 63000);
         
-        function db_connect() {
-            if(!$this->connectionid = mysqli_connect($this->db_host, $this->db_user, $this->db_password)) {
-                echo "Emailqueue Inject class component: Cannot connect to database";
-                die;
+        $content = str_replace("\\'", "'", $content);
+        $content = str_replace("'", "\'", $content);
+        
+        $content_nonhtml = str_replace("\\'", "'", $content_nonhtml);
+        $content_nonhtml = str_replace("'", "\'", $content_nonhtml);
+
+        // Prepare and check attachments array
+        if ($attachments) {
+            if (!is_array($attachments)) {
+                echo "Emailqueue inject error: attachments parameter must be an array.";
+                return false;
             }
-			mysqli_select_db($this->connectionid, $this->db_name);
-			mysqli_query($this->connectionid, "set names utf8");
-        }
-        
-        function db_disconnect() {
-            mysqli_close($this->connectionid);
-        }
-        
-        function inject(
-            $foreign_id_a = null,
-            $foreign_id_b = null,
-            $priority = 10,
-            $is_inmediate = true,
-            $date_queued = null,
-            $is_html = false,
-            $from,
-            $from_name = "",
-            $to,
-            $replyto = "",
-            $replyto_name = "",
-            $subject,
-            $content,
-            $content_nonhtml = "",
-            $list_unsubscribe_url = "",
-            $attachments = false,
-            $is_embed_images = false,
-            $custom_headers = array()
-        ) {
-            $this->db_connect();
-        
-            $subject = str_replace("\\'", "'", $subject);
-            $subject = str_replace("'", "\'", $subject);
-
-            // Some recommendations have been found about not sending emails longer than 63k bytes, it seems that triggers lots of spam-detection alarms.
-            if(strlen($content) > 63000)
-                $content = substr($content, 0, 63000);
-            
-            $content = str_replace("\\'", "'", $content);
-            $content = str_replace("'", "\'", $content);
-            
-            $content_nonhtml = str_replace("\\'", "'", $content_nonhtml);
-            $content_nonhtml = str_replace("'", "\'", $content_nonhtml);
-
-            // Prepare and check attachments array
-            if ($attachments) {
-                if (!is_array($attachments)) {
-                    echo "Emailqueue inject error: attachments parameter must be an array.";
+            foreach ($attachments as $attachment) {
+                if (!is_array($attachment)) {
+                    echo "Emailqueue inject error: Each attachment specified on the attachments array must be a hash array.";
                     return false;
                 }
-                foreach ($attachments as $attachment) {
-                    if (!is_array($attachment)) {
-                        echo "Emailqueue inject error: Each attachment specified on the attachments array must be a hash array.";
-                        return false;
-                    }
-                    if (!file_exists($attachment["path"])) {
-                        echo "Emailqueue inject error: Can't open attached file for reading.";
-                        return false;
-                    }
-                }
-            }
-
-            if ($custom_headers) {
-                if (!is_array($custom_headers)) {
-                    echo "Emailqueue inject error: custom headers parameter must be an array.";
+                if (!file_exists($attachment["path"])) {
+                    echo "Emailqueue inject error: Can't open attached file for reading.";
                     return false;
                 }
             }
-
-            $result = mysqli_query
-            (
-				$this->connectionid,
-				"
-					insert into emails
-					(
-                        foreign_id_a,
-                        foreign_id_b,
-						priority,
-						is_inmediate,
-						is_sent,
-						is_cancelled,
-						is_blocked,
-						is_sendingnow,
-						send_count,
-						error_count,
-						date_injected,
-						date_queued,
-						date_sent,
-						is_html,
-						`from`,
-						from_name,
-						`to`,
-						replyto,
-						replyto_name,
-						subject,
-						content,
-						content_nonhtml,
-						list_unsubscribe_url,
-                        attachments,
-                        is_embed_images,
-                        custom_headers
-					)
-					values
-					(
-						".($foreign_id_a ? $foreign_id_a : "null").",
-						".($foreign_id_b ? $foreign_id_b : "null").",
-						".($priority ? $priority : $this->default_priority).",
-						".($is_inmediate ? "1" : "0").",
-						0,
-						0,
-						0,
-						0,
-						0,
-						0,
-						'".date("Y-n-j H:i:s", $this->timestamp_adjust(mktime(), $this->emailqueue_timezone))."',
-						".($date_queued ? "'".date("Y-n-j H:i:s", $this->timestamp_adjust($date_queued, $this->emailqueue_timezone))."'" : "null").",
-						null,
-						".($is_html ? "1" : "0").",
-						".($from ? "'".$from."'" : "null").",
-						".($from_name ? "'".$from_name."'" : "null").",
-						".($to ? "'".$to."'" : "null").",
-						".($replyto ? "'".$replyto."'" : "null").",
-						".($replyto_name ? "'".$replyto_name."'" : "null").",
-						'".$subject."',
-						'".$content."',
-						'".$content_nonhtml."',
-						'".$list_unsubscribe_url."',
-                        ".($attachments ? "'".serialize($attachments)."'" : "null").",
-                        ".($is_embed_images ? "1" : "0").",
-                        ".($custom_headers ? "'".serialize($custom_headers)."'" : "null")."
-					)
-				"
-			);
-            $this->db_disconnect();
-            
-            return $result ? true : false;
         }
 
-        function timestamp_adjust($timestamp, $to_timezone) {
-            $datetime_object = new DateTime("@".$timestamp);
-
-            $from_timezone_object = new DateTimeZone(date_default_timezone_get());
-            $to_timezone_object = new DateTimeZone($to_timezone);
-
-            $offset = $to_timezone_object->getOffset($datetime_object) - $from_timezone_object->getOffset($datetime_object);
-
-            return $timestamp+$offset;
+        if ($custom_headers) {
+            if (!is_array($custom_headers)) {
+                echo "Emailqueue inject error: custom headers parameter must be an array.";
+                return false;
+            }
         }
 
-        /**
-         * Deletes all emails from the database that have already been delivered.
-         * Useful if for some reason you need to clean your queue without losing any emails that have yet to be sent.
-         * @return boolean True on success, false otherwise
-         */
-        function empty_delivered() {
-            $this->db_connect();
-            $result = mysqli_query($this->connectionid, "
-                delete from
-                    emails
-                where
-                    is_sent = 1
-            ");
-            $this->db_disconnect();
-            return $result ? true : false;
-        }
+        $result = mysqli_query
+        (
+			$this->connectionid,
+			"
+				insert into emails
+				(
+                    foreign_id_a,
+                    foreign_id_b,
+					priority,
+					is_inmediate,
+					is_sent,
+					is_cancelled,
+					is_blocked,
+					is_sendingnow,
+					send_count,
+					error_count,
+					date_injected,
+					date_queued,
+					date_sent,
+					is_html,
+					`from`,
+					from_name,
+					`to`,
+					replyto,
+					replyto_name,
+					subject,
+					content,
+					content_nonhtml,
+					list_unsubscribe_url,
+                    attachments,
+                    is_embed_images,
+                    custom_headers
+				)
+				values
+				(
+					".($foreign_id_a ? $foreign_id_a : "null").",
+					".($foreign_id_b ? $foreign_id_b : "null").",
+					".($priority ? $priority : $this->default_priority).",
+					".($is_inmediate ? "1" : "0").",
+					0,
+					0,
+					0,
+					0,
+					0,
+					0,
+					'".date("Y-n-j H:i:s", $this->timestamp_adjust(mktime(), $this->emailqueue_timezone))."',
+					".($date_queued ? "'".date("Y-n-j H:i:s", $this->timestamp_adjust($date_queued, $this->emailqueue_timezone))."'" : "null").",
+					null,
+					".($is_html ? "1" : "0").",
+					".($from ? "'".$from."'" : "null").",
+					".($from_name ? "'".$from_name."'" : "null").",
+					".($to ? "'".$to."'" : "null").",
+					".($replyto ? "'".$replyto."'" : "null").",
+					".($replyto_name ? "'".$replyto_name."'" : "null").",
+					'".$subject."',
+					'".$content."',
+					'".$content_nonhtml."',
+					'".$list_unsubscribe_url."',
+                    ".($attachments ? "'".serialize($attachments)."'" : "null").",
+                    ".($is_embed_images ? "1" : "0").",
+                    ".($custom_headers ? "'".serialize($custom_headers)."'" : "null")."
+				)
+			"
+		);
+        $this->db_disconnect();
+        
+        return $result ? true : false;
+    }
 
-        /**
-         * Deletes all emails that are in the queue waiting to be sent
-         * Useful if for some reason you need to clean your outgoing queue. This will cause the loss of some emails that should be sent.
-         * @return boolean True on success, false otherwise
-         */
-        function empty_queued() {
-            $this->db_connect();
-            $result = mysqli_query($this->connectionid, "
-                delete from
-                    emails
-                where
-                    is_sent = 0
-            ");
-            $this->db_disconnect();
-            return $result ? true : false;
-        }
+    function timestamp_adjust($timestamp, $to_timezone) {
+        $datetime_object = new DateTime("@".$timestamp);
 
-        /**
-         * Deletes all emails on the queue
-         * Useful if for some reason you need to completely clean your queue. This will cause the loss of some emails that should be sent.
-         * @return boolean True on success, false otherwise
-         */
-        function empty_all() {
-            $this->db_connect();
-            $result = mysqli_query($this->connectionid, "
-                delete from
-                    emails
-            ");
-            $this->db_disconnect();
-            return $result ? true : false;
-        }
+        $from_timezone_object = new DateTimeZone(date_default_timezone_get());
+        $to_timezone_object = new DateTimeZone($to_timezone);
 
-        function destroy() {
-            // Method deprecated, left for compatibility purposes. Will likely be removed on future versions.
-        }
-	}
-	
-?>
+        $offset = $to_timezone_object->getOffset($datetime_object) - $from_timezone_object->getOffset($datetime_object);
+
+        return $timestamp+$offset;
+    }
+
+    /**
+     * Deletes all emails from the database that have already been delivered.
+     * Useful if for some reason you need to clean your queue without losing any emails that have yet to be sent.
+     * @return boolean True on success, false otherwise
+     */
+    function empty_delivered() {
+        $this->db_connect();
+        $result = mysqli_query($this->connectionid, "
+            delete from
+                emails
+            where
+                is_sent = 1
+        ");
+        $this->db_disconnect();
+        return $result ? true : false;
+    }
+
+    /**
+     * Deletes all emails that are in the queue waiting to be sent
+     * Useful if for some reason you need to clean your outgoing queue. This will cause the loss of some emails that should be sent.
+     * @return boolean True on success, false otherwise
+     */
+    function empty_queued() {
+        $this->db_connect();
+        $result = mysqli_query($this->connectionid, "
+            delete from
+                emails
+            where
+                is_sent = 0
+        ");
+        $this->db_disconnect();
+        return $result ? true : false;
+    }
+
+    /**
+     * Deletes all emails on the queue
+     * Useful if for some reason you need to completely clean your queue. This will cause the loss of some emails that should be sent.
+     * @return boolean True on success, false otherwise
+     */
+    function empty_all() {
+        $this->db_connect();
+        $result = mysqli_query($this->connectionid, "
+            delete from
+                emails
+        ");
+        $this->db_disconnect();
+        return $result ? true : false;
+    }
+
+    function destroy() {
+        // Method deprecated, left for compatibility purposes. Will likely be removed on future versions.
+    }
+}

--- a/scripts/purge.php
+++ b/scripts/purge.php
@@ -1,64 +1,61 @@
-<?
+<?php
 
-	/*
-		EMailqueue
-		Purge component
-	*/
-	
-	define("LIB_DIR", "lib");
-	define("APP_DIR", "../");
-	
-	include APP_DIR."common.inc.php";
-	
-	header("content-type: text/plain");
-	set_time_limit(0);
-	
-	echo "Emailqueue · Purge\n";	
-	echo "Purge messages older than ".PURGE_OLDER_THAN_DAYS." days.\n";
-	echo "Process started on: ".date("j/n/Y H:i.s")."\n";
-	
-	$db->query
-	("
-        select          id
-        from            emails
-        where
-        (
-                        is_sent = 1
-        or
-                        is_cancelled = 1
-        )
-        and
-                        is_sendingnow = 0
-        and
-                        date_injected <= '".date("Y-n-j H:i:s", mktime()-(PURGE_OLDER_THAN_DAYS*24*60*60))."'
-	");
-	
-	if(!$db->isanyresult())
-	{
-        echo "No emails to purge.\n";
-	}
-	else
-	{
-        $count = 0;
-        while($row = $db->fetchrow())
-        {
-            $email_ids[] = $row["id"];
-            $count ++;
-        }        
-        echo $count." emails to be purged.\n";
-        
-        $count = 0;
-        foreach($email_ids as $email_id)
-        {
-            $db->query("delete from emails where id = ".$email_id);
-            $db->query("delete from incidences where email_id = ".$email_id);
-            $count ++;
-        }
-        echo $count." emails and related incidences purged.\n";
-	}
-	
-	echo "Process ended on: ".date("j/n/Y H:i.s")."\n";
-	
-	$db->disconnect();
+/*
+	EMailqueue
+	Purge component
+*/
 
-?>
+define("LIB_DIR", "lib");
+define("APP_DIR", "../");
+
+include APP_DIR."common.inc.php";
+
+header("content-type: text/plain");
+set_time_limit(0);
+
+echo "Emailqueue · Purge\n";	
+echo "Purge messages older than ".PURGE_OLDER_THAN_DAYS." days.\n";
+echo "Process started on: ".date("j/n/Y H:i.s")."\n";
+
+$db->query("
+    select          id
+    from            emails
+    where
+    (
+                    is_sent = 1
+    or
+                    is_cancelled = 1
+    )
+    and
+                    is_sendingnow = 0
+    and
+                    date_injected <= '".date("Y-n-j H:i:s", mktime()-(PURGE_OLDER_THAN_DAYS*24*60*60))."'
+");
+
+if(!$db->isanyresult())
+{
+    echo "No emails to purge.\n";
+}
+else
+{
+    $count = 0;
+    while($row = $db->fetchrow())
+    {
+        $email_ids[] = $row["id"];
+        $count ++;
+    }        
+    echo $count." emails to be purged.\n";
+    
+    $count = 0;
+    foreach($email_ids as $email_id)
+    {
+        $db->query("delete from emails where id = ".$email_id);
+        $db->query("delete from incidences where email_id = ".$email_id);
+        $count ++;
+    }
+    echo $count." emails and related incidences purged.\n";
+}
+
+echo "Process ended on: ".date("j/n/Y H:i.s")."\n";
+
+$db->disconnect();


### PR DESCRIPTION
Changing to use long PHP open statement `<?php` instead of shorthand `<?` as it is not supported by default in newer versions of PHP.

Also removed extra tab spacing on the PHP files.