### PR TITLE
fix(common): PHP8 namespace declaration first

### DIFF
--- a/common.inc.php
+++ b/common.inc.php
@@ -1,9 +1,9 @@
 <?php
+	namespace Emailqueue;
 
 	use PHPMailer\PHPMailer\PHPMailer;
     use PHPMailer\PHPMailer\Exception;
 
-	namespace Emailqueue;
 
 	define("VERSION", "3.411");
 	define("OFFICIAL_PAGE_URL", "https://github.com/tin-cat/emailqueue");


### PR DESCRIPTION
Fatal error: Namespace declaration statement has to be the very first statement or after any declare call in the script in /emailqueue/common.inc.php on line 6