### PR TITLE
Change throw and catch Exception on common.inc.php

### DIFF
--- a/common.inc.php
+++ b/common.inc.php
@@ -24,7 +24,7 @@
 		EMAILQUEUE_DB_DATABASE
 	);
 	if (!$db->connect()) {
-		throw new EmailqueueException("Cannot connect to database");
+		throw new \Exception("Cannot connect to database");
 		die;
 	}
 	
@@ -349,7 +349,7 @@
 								if (!isset($attachment["type"])) {
 									if ($finfo = finfo_open(FILEINFO_MIME_TYPE)) {
 										if (!$mimeType = finfo_file($finfo, $attachment["path"]))
-											throw new Exception("Can't guess mimetype for ".$attachment["path"]);
+											throw new \Exception("Can't guess mimetype for ".$attachment["path"]);
 										finfo_close($finfo);
 										$attachment["type"] = $mimeType;
 									}
@@ -372,7 +372,7 @@
 					$isError = true;
 					$errorText = $e->getMessage();
 
-				} catch (Exception $e) {
+				} catch (\Exception $e) {
 
 					$isError = true;
 					$errorText = $e->getMessage();


### PR DESCRIPTION
Important because  the exception `Can't guess mimetype for ".$attachment["path"]` (which happens for instance if an attachment file is not present) is not catched otherwise, with the message remaining in the queue forever with `is_sendingnow` = 1 (and every iteration of the delivery script resulting in a "Try to send an email that is already being sent" incidence).