### PR TITLE
Sync mutual minimum dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "tin-cat/emailqueue",
-	"version": "3.4.12",
+    "name": "tin-cat/emailqueue",
+    "version": "3.4.12",
     "type": "library",
     "description": "A fast, simple yet very efficient email queuing system for PHP/MySQL.",
     "keywords": ["email","queue","queueing","php"],
@@ -16,7 +16,7 @@
     ],
     "require": {
         "phpmailer/phpmailer": "^6.0",
-		"php": ">=5.4",
-		"ext-mysqli": "*"
+        "php": ">=5.5",
+        "ext-mysqli": "*"
     }
 }


### PR DESCRIPTION
Because PHPMailer v6.0.0 requires PHP >= 5.5.0, emailqueue, which requires PHPMailer >= v6.0.0, should increase its own minimum required PHP version to >= 5.5.0, seeing as logically, it would be impossible to run emailqueue on PHP 5.4 as long as it has a dependency requiring PHP >= 5.5.