### PR TITLE
Replace checkemail with PHPMailer implementation

### DIFF
--- a/common.inc.php
+++ b/common.inc.php
@@ -51,7 +51,7 @@
 	$logger = new \Emailqueue\logger;
 
 	function checkemail($email) {
-	return preg_match("/^[.\+\w-]+@([\w-]+\.)+[\w-]{2,15}$/", $email);
+	return PHPMailer::validateAddress($email);
 	}
 
 	function add_incidence($email_id, $description) {


### PR DESCRIPTION
Rely on `PHPMailer::validateAddress` rather than having own regex.

Fixes #44 